### PR TITLE
New Feature method for reset to intial state.

### DIFF
--- a/Source/Fluxor/Feature.cs
+++ b/Source/Fluxor/Feature.cs
@@ -17,6 +17,9 @@ namespace Fluxor
 		/// <see cref="IFeature.RestoreState(object)"/>
 		public virtual void RestoreState(object value) => State = (TState)value;
 
+		/// <see cref="IFeature.ResetToInitialState()"/>
+		public virtual void ResetToInitialState() => State = GetInitialState();
+
 		/// <see cref="IFeature.GetStateType"/>
 		public virtual Type GetStateType() => typeof(TState);
 

--- a/Source/Fluxor/IFeature.cs
+++ b/Source/Fluxor/IFeature.cs
@@ -37,6 +37,13 @@ namespace Fluxor
 		void RestoreState(object value);
 
 		/// <summary>
+		/// Reset the current state of the feature to the initial state. This should only be used by Middleware, not for mutating
+		/// state within an application.
+		/// </summary>
+		/// <seealso cref="IMiddleware"/>
+		void ResetToInitialState();
+
+		/// <summary>
 		/// Allows a feature to react to an action dispatched via the store. This should not be called by
 		/// consuming applications. Instead you should dispatch actions only via <see cref="IDispatcher.Dispatch(object)"/>
 		/// </summary>


### PR DESCRIPTION
For the development of a custom middleware that persists the store over a page reload, a method to reset  the states to their initial value is required. e.g. a LogoutAction should reset most of the store to its intial state