### PR TITLE
Release/3.7

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -7,11 +7,13 @@
  * Fix for ([#82](https://github.com/mrpmorris/Fluxor/issues/82)) -
    Throw an informative exception when `FluxorComponent` or `FluxorLayout`
    has been inherited and the descendant doesn't call `base.OnInitialized()`.
+ * Fix for ([#77](https://github.com/mrpmorris/Fluxor/issues/87)) -
+   Exception thrown initialising store in .NET 5.
 
 ### New in 3.6
  * Ensure synchronous effects are executed synchronously ([#76](https://github.com/mrpmorris/fluxor/issues/76)) -
-     Reverts changes for [(#74) Endless loop redirects](https://github.com/mrpmorris/Fluxor/issues/74) as
-     these are no longer occur.
+   Reverts changes for [(#74) Endless loop redirects](https://github.com/mrpmorris/Fluxor/issues/74) as
+   these are no longer occur.
 
 ### New in 3.5
  * Bug fix for ([#74](https://github.com/mrpmorris/Fluxor/issues/74)) - Handle endless loop redirects caused by Routing middleware.

--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -4,6 +4,9 @@
  * Fix for ([#84](https://github.com/mrpmorris/Fluxor/issues/84) - 
    Allow observer to unsubscribe from all subscriptions whilst executing
    the callback from a previous subscription
+ * Fix for ([#82](https://github.com/mrpmorris/Fluxor/issues/82)) -
+   Throw an informative exception when `FluxorComponent` or `FluxorLayout`
+   has been inherited and the descendant doesn't call `base.OnInitialized()`.
 
 ### New in 3.6
  * Ensure synchronous effects are executed synchronously ([#76](https://github.com/mrpmorris/fluxor/issues/76)) -

--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -1,5 +1,10 @@
 # Releases
 
+### New in 3.7
+ * Fix for ([#84](https://github.com/mrpmorris/Fluxor/issues/84) - 
+   Allow observer to unsubscribe from all subscriptions whilst executing
+   the callback from a previous subscription
+
 ### New in 3.6
  * Ensure synchronous effects are executed synchronously ([#76](https://github.com/mrpmorris/fluxor/issues/76)) -
      Reverts changes for [(#74) Endless loop redirects](https://github.com/mrpmorris/Fluxor/issues/74) as

--- a/Source/Fluxor.Blazor.Web.ReduxDevTools/Fluxor.Blazor.Web.ReduxDevTools.csproj
+++ b/Source/Fluxor.Blazor.Web.ReduxDevTools/Fluxor.Blazor.Web.ReduxDevTools.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<RazorLangVersion>3.0</RazorLangVersion>
-		<Version>3.6.0</Version>
+		<Version>3.7.0</Version>
 		<Authors>Peter Morris</Authors>
 		<Company />
 		<Product>ReduxDevTools for Fluxor Blazor (Web)</Product>
@@ -17,8 +17,8 @@
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Redux Flux DotNet CSharp Blazor RazorComponents ReduxDevTools</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<AssemblyVersion>3.6.0.0</AssemblyVersion>
-		<FileVersion>3.6.0.0</FileVersion>
+		<AssemblyVersion>3.7.0.0</AssemblyVersion>
+		<FileVersion>3.7.0.0</FileVersion>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>MrPMorris.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>

--- a/Source/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -44,6 +44,9 @@ namespace Fluxor.Blazor.Web.Components
 			{
 				if (disposing)
 				{
+					if (StateSubscription == null)
+						throw new NullReferenceException(ErrorMessages.ForgottenToCallBaseOnInitialized);
+
 					StateSubscription.Dispose();
 					ActionSubscriber?.UnsubscribeFromAllActions(this);
 				}

--- a/Source/Fluxor.Blazor.Web/Components/FluxorLayout.cs
+++ b/Source/Fluxor.Blazor.Web/Components/FluxorLayout.cs
@@ -44,6 +44,9 @@ namespace Fluxor.Blazor.Web.Components
 			{
 				if (disposing)
 				{
+					if (StateSubscription == null)
+						throw new NullReferenceException(ErrorMessages.ForgottenToCallBaseOnInitialized);
+
 					StateSubscription.Dispose();
 					ActionSubscriber?.UnsubscribeFromAllActions(this);
 				}

--- a/Source/Fluxor.Blazor.Web/ErrorMessages.cs
+++ b/Source/Fluxor.Blazor.Web/ErrorMessages.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluxor.Blazor.Web
+{
+	internal class ErrorMessages
+	{
+		internal const string ForgottenToCallBaseOnInitialized =
+			"Have you forgotten to call base.OnInitialized() in your component?";
+	}
+}

--- a/Source/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
+++ b/Source/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
@@ -5,7 +5,7 @@
 		<RazorLangVersion>3.0</RazorLangVersion>
 		<Authors>Peter Morris</Authors>
 		<Company />
-		<Version>3.6.0</Version>
+		<Version>3.7.0</Version>
 		<Description>A zero boilerplate Redux/Flux framework for Blazor</Description>
 		<Copyright>Peter Morris</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -17,8 +17,8 @@
 		<PackageTags>Redux Flux DotNet CSharp Blazor RazorComponents</PackageTags>
 		<Product>Fluxor for Blazor (Web)</Product>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-		<AssemblyVersion>3.6.0.0</AssemblyVersion>
-		<FileVersion>3.6.0.0</FileVersion>
+		<AssemblyVersion>3.7.0.0</AssemblyVersion>
+		<FileVersion>3.7.0.0</FileVersion>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>MrPMorris.snk</AssemblyOriginatorKeyFile>
 	</PropertyGroup>

--- a/Source/Fluxor.sln
+++ b/Source/Fluxor.sln
@@ -93,9 +93,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicConcepts.StateActionsReducersTutorial", "..\Tutorials\01-BasicConcepts\01A-StateActionsReducersTutorial\StateActionsReducersTutorial\BasicConcepts.StateActionsReducersTutorial.csproj", "{5E423494-7C7A-485E-8E84-A5CD11F7C504}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "01E-ActionSubscriber", "01E-ActionSubscriber", "{6118BA67-8200-42C8-8A6D-B65E085E07A0}"
-	ProjectSection(SolutionItems) = preProject
-		..\Tutorials\01-BasicConcepts\01E-ActionObserver\README.md = ..\Tutorials\01-BasicConcepts\01E-ActionObserver\README.md
-	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicConcepts.ActionSubscriber", "..\Tutorials\01-BasicConcepts\01E-ActionSubscriber\ActionSubscriber\BasicConcepts.ActionSubscriber.csproj", "{E7D0352B-16E1-4A89-8C29-ED119FF03316}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -323,6 +322,18 @@ Global
 		{5E423494-7C7A-485E-8E84-A5CD11F7C504}.Release|iPhone.Build.0 = Release|Any CPU
 		{5E423494-7C7A-485E-8E84-A5CD11F7C504}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{5E423494-7C7A-485E-8E84-A5CD11F7C504}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|iPhone.Build.0 = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -353,6 +364,7 @@ Global
 		{A56E9867-7EB6-4EF6-A641-737C77E62B37} = {14D676FF-AC1C-4912-81D0-9B98B8B090D8}
 		{5E423494-7C7A-485E-8E84-A5CD11F7C504} = {4DB29E0A-3D0F-4CD5-AD58-3701BF3C23CC}
 		{6118BA67-8200-42C8-8A6D-B65E085E07A0} = {755410A3-91C0-4CD3-B234-1DEAE35F19DA}
+		{E7D0352B-16E1-4A89-8C29-ED119FF03316} = {6118BA67-8200-42C8-8A6D-B65E085E07A0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1F2E0DF-C651-48A3-83E3-3B77D34EC3A2}

--- a/Source/Fluxor/ActionSubscriber.cs
+++ b/Source/Fluxor/ActionSubscriber.cs
@@ -34,7 +34,8 @@ namespace Fluxor
 					SubscriptionsForType
 						.Where(x => x.Key.IsAssignableFrom(action.GetType()))
 						.SelectMany(x => x.Value)
-						.Select(x => x.Callback);
+						.Select(x => x.Callback)
+						.ToArray();
 				foreach (Action<object> callback in callbacks)
 					callback(action);
 			});

--- a/Source/Fluxor/Fluxor.csproj
+++ b/Source/Fluxor/Fluxor.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
-		<Version>3.6.0</Version>
+		<Version>3.7.0</Version>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>Peter Morris</Authors>
 		<Company />
@@ -16,8 +16,8 @@
 		<PackageLicenseFile></PackageLicenseFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<RepositoryType>git</RepositoryType>
-		<AssemblyVersion>3.6.0.0</AssemblyVersion>
-		<FileVersion>3.6.0.0</FileVersion>
+		<AssemblyVersion>3.7.0.0</AssemblyVersion>
+		<FileVersion>3.7.0.0</FileVersion>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>MrPMorris.snk</AssemblyOriginatorKeyFile>
 		<DelaySign>false</DelaySign>

--- a/Source/Fluxor/Store.cs
+++ b/Source/Fluxor/Store.cs
@@ -27,7 +27,6 @@ namespace Fluxor
 		private volatile int BeginMiddlewareChangeCount;
 		private volatile bool HasActivatedStore;
 		private bool IsInsideMiddlewareChange => BeginMiddlewareChangeCount > 0;
-		private Action<IFeature, object> IFeatureReceiveDispatchNotificationFromStore;
 
 		/// <summary>
 		/// Creates an instance of the store
@@ -35,13 +34,6 @@ namespace Fluxor
 		public Store()
 		{
 			ActionSubscriber = new ActionSubscriber();
-
-			MethodInfo dispatchNotifictionFromStoreMethodInfo =
-				typeof(IFeature)
-				.GetMethod(nameof(IFeature.ReceiveDispatchNotificationFromStore));
-			IFeatureReceiveDispatchNotificationFromStore = (Action<IFeature, object>)
-				Delegate.CreateDelegate(typeof(Action<IFeature, object>), dispatchNotifictionFromStoreMethodInfo);
-
 			Dispatch(new StoreInitializedAction());
 		}
 
@@ -283,7 +275,7 @@ namespace Fluxor
 
 						// Notify all features of this action
 						foreach (var featureInstance in FeaturesByName.Values)
-							IFeatureReceiveDispatchNotificationFromStore(featureInstance, nextActionToProcess);
+							featureInstance.ReceiveDispatchNotificationFromStore(nextActionToProcess);
 
 						ExecuteMiddlewareAfterDispatch(nextActionToProcess);
 						TriggerEffects(nextActionToProcess);

--- a/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorComponentTests/DisposeTests.cs
+++ b/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorComponentTests/DisposeTests.cs
@@ -1,29 +1,58 @@
 ﻿using Fluxor.Blazor.Web.UnitTests.SupportFiles;
+using System;
 using Xunit;
 
 namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorComponentTests
 {
 	public class DisposeTests
 	{
-		private readonly FluxorComponentWithStateProperties Subject;
+		private readonly FluxorComponentWithStateProperties StateSubject;
 		private readonly MockState<int> MockState1;
 		private readonly MockState<int> MockState2;
 
 		[Fact]
 		public void UnsubscribesFromStateProperties()
 		{
-			Subject.ExecuteOnInitialized();
-			Subject.Dispose();
+			StateSubject.ExecuteOnInitialized();
+			StateSubject.Dispose();
 
 			Assert.Equal(1, MockState1.UnsubscribeCount);
 			Assert.Equal(1, MockState2.UnsubscribeCount);
+		}
+
+		[Fact]
+		public void WhenBaseOnInitializedWasNotCalled_ThenThrowsNullReferenceException()
+		{
+			string errorMessage = null;
+			var component = new FluxorComponentThatOptionallyCallsBaseOnInitialized();
+			try
+			{
+				component.Test_OnInitialized();
+				component.Dispose();
+			}
+			catch (NullReferenceException e)
+			{
+				errorMessage = e.Message;
+			}
+			Assert.Equal("Have you forgotten to call base.OnInitialized() in your component?", errorMessage);
+		}
+
+		[Fact]
+		public void WhenBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
+		{
+			var component = new FluxorComponentThatOptionallyCallsBaseOnInitialized
+			{
+				CallBaseOnInitialized = true
+			};
+			component.Test_OnInitialized();
+			component.Dispose();
 		}
 
 		public DisposeTests()
 		{
 			MockState1 = new MockState<int>();
 			MockState2 = new MockState<int>();
-			Subject = new FluxorComponentWithStateProperties
+			StateSubject = new FluxorComponentWithStateProperties
 			{
 				State1 = MockState1,
 				State2 = MockState2

--- a/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorLayoutTests/DisposeTests.cs
+++ b/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorLayoutTests/DisposeTests.cs
@@ -1,29 +1,57 @@
 ﻿using Fluxor.Blazor.Web.UnitTests.SupportFiles;
+using System;
 using Xunit;
 
 namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorLayoutTests
 {
 	public class DisposeTests
 	{
-		private readonly FluxorLayoutWithStateProperties Subject;
+		private readonly FluxorLayoutWithStateProperties StateSubject;
 		private readonly MockState<int> MockState1;
 		private readonly MockState<int> MockState2;
 
 		[Fact]
 		public void UnsubscribesFromStateProperties()
 		{
-			Subject.ExecuteOnInitialized();
-			Subject.Dispose();
+			StateSubject.ExecuteOnInitialized();
+			StateSubject.Dispose();
 
 			Assert.Equal(1, MockState1.UnsubscribeCount);
 			Assert.Equal(1, MockState2.UnsubscribeCount);
 		}
 
+		[Fact]
+		public void WhenBaseOnInitializedWasNotCalled_ThenThrowsNullReferenceException()
+		{
+			string errorMessage = null;
+			var layout = new FluxorLayoutThatOptionallyCallsBaseOnInitialized();
+			try
+			{
+				layout.Test_OnInitialized();
+				layout.Dispose();
+			}
+			catch (NullReferenceException e)
+			{
+				errorMessage = e.Message;
+			}
+			Assert.Equal("Have you forgotten to call base.OnInitialized() in your component?", errorMessage);
+		}
+
+		[Fact]
+		public void WhenBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
+		{
+			var layout = new FluxorLayoutThatOptionallyCallsBaseOnInitialized
+			{
+				CallBaseOnInitialized = true
+			};
+			layout.Test_OnInitialized();
+			layout.Dispose();
+		}
 		public DisposeTests()
 		{
 			MockState1 = new MockState<int>();
 			MockState2 = new MockState<int>();
-			Subject = new FluxorLayoutWithStateProperties
+			StateSubject = new FluxorLayoutWithStateProperties
 			{
 				State1 = MockState1,
 				State2 = MockState2

--- a/Tests/Fluxor.Blazor.Web.UnitTests/SupportFiles/FluxorComponentThatOptionallyCallsBaseOnInitialized.cs
+++ b/Tests/Fluxor.Blazor.Web.UnitTests/SupportFiles/FluxorComponentThatOptionallyCallsBaseOnInitialized.cs
@@ -1,0 +1,17 @@
+﻿using Fluxor.Blazor.Web.Components;
+
+namespace Fluxor.Blazor.Web.UnitTests.SupportFiles
+{
+	public class FluxorComponentThatOptionallyCallsBaseOnInitialized : FluxorComponent
+	{
+		public bool CallBaseOnInitialized;
+
+		protected override void OnInitialized()
+		{
+			if (CallBaseOnInitialized)
+				base.OnInitialized();
+		}
+
+		public void Test_OnInitialized() => OnInitialized();
+	}
+}

--- a/Tests/Fluxor.Blazor.Web.UnitTests/SupportFiles/FluxorLayoutThatOptionallyCallsBaseOnInitialized.cs
+++ b/Tests/Fluxor.Blazor.Web.UnitTests/SupportFiles/FluxorLayoutThatOptionallyCallsBaseOnInitialized.cs
@@ -1,0 +1,17 @@
+﻿using Fluxor.Blazor.Web.Components;
+
+namespace Fluxor.Blazor.Web.UnitTests.SupportFiles
+{
+	public class FluxorLayoutThatOptionallyCallsBaseOnInitialized : FluxorLayout
+	{
+		public bool CallBaseOnInitialized;
+
+		protected override void OnInitialized()
+		{
+			if (CallBaseOnInitialized)
+				base.OnInitialized();
+		}
+
+		public void Test_OnInitialized() => OnInitialized();
+	}
+}

--- a/Tests/Fluxor.UnitTests/ActionSubscriberTests/UnsubscribeFromAllActionsTests.cs
+++ b/Tests/Fluxor.UnitTests/ActionSubscriberTests/UnsubscribeFromAllActionsTests.cs
@@ -38,5 +38,24 @@ namespace Fluxor.UnitTests.ActionSubscriberTests
 			Assert.Null(actionReceivedBySubscriber1);
 			Assert.Same(dispatchedAction, actionReceivedBySubscriber2);
 		}
+
+		[Fact]
+		public void WhenExecutedFromSubscriptionCallback_ThenDoesNotThrowAnError()
+		{
+			int executionCount = 0;
+			var subscriber = new object();
+			var dispatchedAction = new TestAction();
+
+			Subject.SubscribeToAction<TestAction>(subscriber, x =>
+			{
+				executionCount++;
+				Subject.UnsubscribeFromAllActions(subscriber);
+			});
+
+			Subject.Dispatch(dispatchedAction);
+			Subject.Dispatch(dispatchedAction);
+
+			Assert.Equal(1, executionCount);
+		}
 	}
 }

--- a/Tutorials/01-BasicConcepts/01E-ActionSubscriber/ActionSubscriber/README.md
+++ b/Tutorials/01-BasicConcepts/01E-ActionSubscriber/ActionSubscriber/README.md
@@ -1,0 +1,221 @@
+# Fluxor - Basic concepts
+
+## IActionSubscriber
+`IActionSubscriber` allows us to subscribe to the dispatch pipeline and be notifified
+whenever an action has been dispatched.
+
+One particularly useful example of this is when we wish to retrieve
+a mutable object from an API server that we can edit in our application
+without having to store that mutable object in our immutable state.
+
+Another is when an action such as `CustomerSearchAction` is dispatched
+and the UI needs to know when it is complete so it can set focus
+to a specific control.
+
+### Goal
+This tutorial will demonstrate how to subscribe to be notified whenever
+a specific action is dispatched. When the subscriber is notified, a JSON
+representation of the action will be displayed in the console.
+
+### Steps
+
+Create a folder named `ApiObjects` and then add the following class. This class would normally be
+in a separate assembly that is shared between the client and the server.
+
+```C#
+public class CustomerEdit
+{
+	public int Id { get; set; } = 42;
+	public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+	public string Name { get; set; }
+
+	public CustomerEdit() { }
+	public CustomerEdit(int id, byte[] rowVersion, string name)
+	{
+		Id = id;
+		RowVersion = rowVersion;
+		Name = name;
+	}}
+```
+
+Create a `Store` folder, and in that folder create a folder named `EditCustomerUseCase`. Within
+that folder we need the standard classes to define our feature, our state, and the
+actions/reducers/effects that we need to emulate retrieving a mutable object from an API service.
+
+```C#
+public class EditCustomerState
+{
+	public bool IsLoading { get; private set; }
+
+	public EditCustomerState(bool isLoading)
+	{
+		IsLoading = isLoading;
+	}
+}
+
+public class Feature : Feature<EditCustomerState>
+{
+	public override string GetName() => "EditCustomer";
+
+	protected override EditCustomerState GetInitialState() =>
+		new EditCustomerState(isLoading: false);
+}
+
+public class GetCustomerForEditAction
+{
+	public int Id { get; }
+
+	public GetCustomerForEditAction(int id)
+	{
+		Id = id;
+	}
+}
+
+public class GetCustomerForEditResultAction
+{
+	public CustomerEdit Customer { get; }
+
+	public GetCustomerForEditResultAction(CustomerEdit customer)
+	{
+		Customer = customer;
+	}
+}
+
+public static class Reducers
+{
+	[ReducerMethod]
+	public static EditCustomerState Reduce(EditCustomerState state, GetCustomerForEditAction action) =>
+		new EditCustomerState(isLoading: true);
+
+	[ReducerMethod]
+	public static EditCustomerState Reduce(EditCustomerState state, GetCustomerForEditResultAction action) =>
+		new EditCustomerState(isLoading: false);
+}
+
+public class Effects
+{
+	[EffectMethod]
+	public async Task HandleGetCustomerForEditAction(GetCustomerForEditAction action, IDispatcher dispatcher)
+	{
+		Console.WriteLine("Getting customer with Id: 42");
+
+		await Task.Delay(1000);
+
+		string jsonFromServer = $"{{\"Id\":42,\"RowVersion\":\"AQIDBAUGBwgJCgsMDQ4PEA==\",\"Name\":\"Our first customer\"}}";
+		var objectFromServer = JsonConvert.DeserializeObject<CustomerEdit>(jsonFromServer);
+		dispatcher.Dispatch(new GetCustomerForEditResultAction(objectFromServer));
+	}
+}
+```
+
+#### Create an App to test our store
+
+```C#
+public class App : IDisposable
+{
+	private readonly IStore Store;
+	public readonly IDispatcher Dispatcher;
+	private readonly IActionSubscriber ActionSubscriber;
+
+	public App(IStore store, IDispatcher dispatcher, IActionSubscriber actionSubscriber)
+	{
+		Store = store;
+		Dispatcher = dispatcher;
+		ActionSubscriber = actionSubscriber;
+	}
+
+	public void Run()
+	{
+		Console.Clear();
+		Console.WriteLine("Initializing store");
+		Store.InitializeAsync().Wait();
+		SubscribeToResultAction();
+		string input = "";
+		do
+		{
+			Console.WriteLine("1: Get mutable object from API server");
+			Console.WriteLine("x: Exit");
+			Console.Write("> ");
+			input = Console.ReadLine();
+
+			switch (input.ToLowerInvariant())
+			{
+				case "1":
+					var getCustomerAction = new GetCustomerForEditAction(42);
+					Dispatcher.Dispatch(getCustomerAction);
+					break;
+
+				case "x":
+					Console.WriteLine("Program terminated");
+					return;
+			}
+		} while (true);
+	}
+
+	private void SubscribeToResultAction()
+	{
+		// We'll implement this shortly
+	}
+
+
+	void IDisposable.Dispose()
+	{
+		// We'll implement this shortly
+	}
+}
+```
+
+#### Bootstrapping our app
+Replace the `Main` method in `Program.cs` to execute our test app.
+
+```C#
+static void Main(string[] args)
+{
+	var services = new ServiceCollection();
+	services.AddScoped<App>();
+	services.AddFluxor(o => o
+		.ScanAssemblies(typeof(Program).Assembly));
+
+	IServiceProvider serviceProvider = services.BuildServiceProvider();
+
+	var app = serviceProvider.GetRequiredService<App>();
+	app.Run();
+}
+```
+
+#### Subscribing to actions
+Edit the `App` class and implement the following two methods:
+
+```C#
+private void SubscribeToResultAction()
+{
+	Console.WriteLine($"Subscribing to action {nameof(GetCustomerForEditResultAction)}");
+	ActionSubscriber.SubscribeToAction<GetCustomerForEditResultAction>(this, action =>
+	{
+		// Show the object from the server in the console
+		string jsonToShowInConsole = JsonConvert.SerializeObject(action.Customer, Formatting.Indented);
+		Console.WriteLine("Action notification: " + action.GetType().Name);
+		Console.WriteLine(jsonToShowInConsole);
+	});
+}
+
+void IDisposable.Dispose()
+{
+	// IMPORTANT: Unsubscribe to avoid memory leaks!
+	ActionSubscriber.UnsubscribeFromAllActions(this);
+}
+```
+
+### Running our app
+
+If we run our app now, and select option 1 (and press enter), our
+console output should look something like this.
+
+```
+> Action notification: GetCustomerForEditResultAction
+{
+  "Id": 42,
+  "RowVersion": "AQIDBAUGBwgJCgsMDQ4PEA==",
+  "Name": "Our first customer"
+}
+```


### PR DESCRIPTION
* Fix for #84 - Allow observer to unsubscribe from all subscriptions whilst executing the callback from a previous subscription
* Fix for #82 - Throw an informative exception when `FluxorComponent` or `FluxorLayout` has been inherited and the descendant doesn't call `base.OnInitialized()`.
* Fix for #77 - Exception thrown initialising store in .NET 5.
