### PR TITLE
Allow ReducerMethods and EffectMethods on generic classes (Fixes #110)

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -41,6 +41,60 @@ public class SomeReducers
 }
 ```
 
+ * Added support for declaring `[ReducerMethod]` on generic classes
+
+```c#
+public class TestIntReducer: AbstractGenericStateReducers<int>
+{
+}
+
+public class TestStringReducer: AbstractGenericStateReducers<string>
+{
+}
+
+public abstract class AbstractGenericStateReducers<T>
+	where T : IEquatable<T>
+{
+	[ReducerMethod]
+	public static TestState<T> ReduceRemoveItemAction(TestState<T> state, RemoveItemAction<T> action) =>
+		new TestState<T>(state.Items.Where(x => !x.Equals(action.Item)).ToArray());
+}
+```
+
+ * Added support for declaring `[EffectMethod]` on generic classes
+
+```c#
+public class GenericEffectClassForMyAction : AbstractGenericEffectClass<MyAction>
+{
+	public GenericEffectClassForMyAction(SomeService someService) : base(someService)
+	{
+	}
+}
+
+public class GenericEffectClassForAnotherAction : AbstractGenericEffectClass<AnotherAction>
+{
+	public GenericEffectClassForAnotherAction(SomeService someService) : base(someService)
+	{
+	}
+}
+
+public abstract class AbstractGenericEffectClass<T> 
+{
+	private readonly ISomeService SomeService;
+
+	protected AbstractGenericEffectClass(ISomeService someService)
+	{
+		SomeService = someService;
+	}
+
+	[EffectMethod]
+	public Task HandleTheActionAsync(T action, IDispatcher dispatcher)
+	{
+		return SomeService.DoSomethingAsync(action);
+	}
+}
+```
+
 ### New in 3.7
  * Fix for ([#84](https://github.com/mrpmorris/Fluxor/issues/84) - 
    Allow observer to unsubscribe from all subscriptions whilst executing

--- a/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
+++ b/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
@@ -39,9 +39,9 @@ namespace Fluxor.DependencyInjection
 		public static MethodInfo[] FilterMethods(IEnumerable<Type> allCandidateTypes) =>
 			allCandidateTypes
 				.SelectMany(t =>
-					t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+					t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy))
 				.Where(m =>
-					m.GetCustomAttributes(false).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
+					m.GetCustomAttributes(true).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
 				.ToArray();
 
 		public override bool Equals(object obj)

--- a/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
+++ b/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
@@ -36,12 +36,23 @@ namespace Fluxor.DependencyInjection
 						|| !scanExcludeList.Any(excl => excl.Matches(t)))
 					.ToArray();
 
-		public static MethodInfo[] FilterMethods(IEnumerable<Type> allCandidateTypes) =>
+		public static TypeAndMethodInfo[] FilterMethods(IEnumerable<Type> allCandidateTypes) =>
 			allCandidateTypes
-				.SelectMany(t =>
-					t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.FlattenHierarchy))
-				.Where(m =>
-					m.GetCustomAttributes(true).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
+				.Select(t =>
+					new
+					{
+						Type = t,
+						Methods = t
+							.GetMethods(
+								BindingFlags.Public
+								| BindingFlags.Instance
+								| BindingFlags.Static
+								| BindingFlags.FlattenHierarchy)
+							.Where(m =>
+								m.GetCustomAttributes(true).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
+					})
+				.SelectMany(x => x.Methods
+					.Select(m => new TypeAndMethodInfo(x.Type, m)))
 				.ToArray();
 
 		public override bool Equals(object obj)

--- a/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
+++ b/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
@@ -39,10 +39,7 @@ namespace Fluxor.DependencyInjection
 		public static MethodInfo[] FilterMethods(IEnumerable<Type> allCandidateTypes) =>
 			allCandidateTypes
 				.SelectMany(t =>
-					t.GetMethods(BindingFlags.Public | BindingFlags.Instance 
-						//TODO: PeteM - Remove DeclaredOnly
-						| BindingFlags.DeclaredOnly
-						| BindingFlags.Static))
+					t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
 				.Where(m =>
 					m.GetCustomAttributes(false).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
 				.ToArray();

--- a/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
+++ b/Source/Fluxor/DependencyInjection/AssemblyScanSettings.cs
@@ -39,7 +39,10 @@ namespace Fluxor.DependencyInjection
 		public static MethodInfo[] FilterMethods(IEnumerable<Type> allCandidateTypes) =>
 			allCandidateTypes
 				.SelectMany(t =>
-					t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Static))
+					t.GetMethods(BindingFlags.Public | BindingFlags.Instance 
+						//TODO: PeteM - Remove DeclaredOnly
+						| BindingFlags.DeclaredOnly
+						| BindingFlags.Static))
 				.Where(m =>
 					m.GetCustomAttributes(false).Any(a => a is ReducerMethodAttribute || a is EffectMethodAttribute))
 				.ToArray();

--- a/Source/Fluxor/DependencyInjection/DependencyScanner.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanner.cs
@@ -78,6 +78,7 @@ namespace Fluxor.DependencyInjection
 					allCandidateAssemblies
 						.SelectMany(x => x.GetTypes())
 						.Union(scanIncludeList.SelectMany(x => x.Assembly.GetTypes()))
+						.Where(t => !t.IsGenericType)
 						.Distinct()
 						.ToArray());
 			allNonAbstractCandidateTypes = allCandidateTypes

--- a/Source/Fluxor/DependencyInjection/DependencyScanner.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanner.cs
@@ -32,7 +32,7 @@ namespace Fluxor.DependencyInjection
 				EffectClassessDiscovery.DiscoverEffectClasses(serviceCollection, allNonAbstractCandidateTypes);
 
 			// Method reducer/effects may belong to abstract classes
-			MethodInfo[] allCandidateMethods = AssemblyScanSettings.FilterMethods(allCandidateTypes);
+			TypeAndMethodInfo[] allCandidateMethods = AssemblyScanSettings.FilterMethods(allCandidateTypes);
 
 			DiscoveredReducerMethod[] discoveredReducerMethods =
 				ReducerMethodsDiscovery.DiscoverReducerMethods(serviceCollection, allCandidateMethods);

--- a/Source/Fluxor/DependencyInjection/DependencyScanners/EffectMethodsDiscovery.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanners/EffectMethodsDiscovery.cs
@@ -8,7 +8,8 @@ namespace Fluxor.DependencyInjection.DependencyScanners
 {
 	internal static class EffectMethodsDiscovery
 	{
-		internal static DiscoveredEffectMethod[] DiscoverEffectMethods(IServiceCollection serviceCollection,
+		internal static DiscoveredEffectMethod[] DiscoverEffectMethods(
+			IServiceCollection serviceCollection,
 			IEnumerable<MethodInfo> allCandidateMethods)
 		{
 			DiscoveredEffectMethod[] discoveredEffects =

--- a/Source/Fluxor/DependencyInjection/DependencyScanners/EffectMethodsDiscovery.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanners/EffectMethodsDiscovery.cs
@@ -10,18 +10,23 @@ namespace Fluxor.DependencyInjection.DependencyScanners
 	{
 		internal static DiscoveredEffectMethod[] DiscoverEffectMethods(
 			IServiceCollection serviceCollection,
-			IEnumerable<MethodInfo> allCandidateMethods)
+			IEnumerable<TypeAndMethodInfo> allCandidateMethods)
 		{
 			DiscoveredEffectMethod[] discoveredEffects =
 				allCandidateMethods
-					.Select(m =>
+					.Select(c =>
 						new
 						{
-							MethodInfo = m,
-							EffectAttribute = m.GetCustomAttribute<EffectMethodAttribute>(false)
+							HostClassType = c.Type,
+							c.MethodInfo,
+							EffectAttribute = c.MethodInfo.GetCustomAttribute<EffectMethodAttribute>(false)
 						})
 					.Where(x => x.EffectAttribute != null)
-					.Select(x => new DiscoveredEffectMethod(x.EffectAttribute, x.MethodInfo))
+					.Select(x =>
+						new DiscoveredEffectMethod(
+							x.HostClassType,
+							x.EffectAttribute, 
+							x.MethodInfo))
 					.ToArray();
 
 			IEnumerable<Type> hostClassTypes =

--- a/Source/Fluxor/DependencyInjection/DependencyScanners/FeatureClassesDiscovery.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanners/FeatureClassesDiscovery.cs
@@ -20,14 +20,9 @@ namespace Fluxor.DependencyInjection.DependencyScanners
 				.GroupBy(x => x.StateType)
 				.ToDictionary(x => x.Key);
 
-			var getReducerMethodKey = new Func<Type, string>(x =>
-				x.IsGenericType
-				? x.Name
-				: x.FullName);
-
-			Dictionary<string, IGrouping<string, DiscoveredReducerMethod>> discoveredReducerMethodsByStateType =
+			Dictionary<Type, IGrouping<Type, DiscoveredReducerMethod>> discoveredReducerMethodsByStateType =
 				discoveredReducerMethods
-					.GroupBy(x => getReducerMethodKey(x.StateType))
+					.GroupBy(x => x.StateType)
 					.ToDictionary(x => x.Key);
 
 			DiscoveredFeatureClass[] discoveredFeatureClasses =
@@ -53,8 +48,8 @@ namespace Fluxor.DependencyInjection.DependencyScanners
 					out IGrouping<Type, DiscoveredReducerClass> discoveredReducerClassesForStateType);
 
 				discoveredReducerMethodsByStateType.TryGetValue(
-					getReducerMethodKey(discoveredFeatureClass.StateType),
-					out IGrouping<string, DiscoveredReducerMethod> discoveredReducerMethodsForStateType);
+					discoveredFeatureClass.StateType,
+					out IGrouping<Type, DiscoveredReducerMethod> discoveredReducerMethodsForStateType);
 
 				RegisterFeature(
 					serviceCollection,

--- a/Source/Fluxor/DependencyInjection/DependencyScanners/ReducerMethodsDiscovery.cs
+++ b/Source/Fluxor/DependencyInjection/DependencyScanners/ReducerMethodsDiscovery.cs
@@ -10,18 +10,22 @@ namespace Fluxor.DependencyInjection.DependencyScanners
 	{
 		internal static DiscoveredReducerMethod[] DiscoverReducerMethods(
 			IServiceCollection serviceCollection,
-			IEnumerable<MethodInfo> allCandidateMethods)
+			IEnumerable<TypeAndMethodInfo> allCandidateMethods)
 		{
 			DiscoveredReducerMethod[] discoveredReducers =
 				allCandidateMethods
-					.Select(m =>
+					.Select(c =>
 						new
 						{
-							MethodInfo = m,
-							ReducerAttribute = m.GetCustomAttribute<ReducerMethodAttribute>(false)
+							HostClassType = c.Type, 
+							c.MethodInfo,
+							ReducerAttribute = c.MethodInfo.GetCustomAttribute<ReducerMethodAttribute>(false)
 						})
 					.Where(x => x.ReducerAttribute != null)
-					.Select(x => new DiscoveredReducerMethod(x.ReducerAttribute, x.MethodInfo))
+					.Select(x => new DiscoveredReducerMethod(
+						x.HostClassType,
+						x.ReducerAttribute,
+						x.MethodInfo))
 					.ToArray();
 
 			IEnumerable<Type> hostClassTypes =

--- a/Source/Fluxor/DependencyInjection/DiscoveredEffectMethod.cs
+++ b/Source/Fluxor/DependencyInjection/DiscoveredEffectMethod.cs
@@ -12,7 +12,10 @@ namespace Fluxor.DependencyInjection
 		public readonly Type ActionType;
 		public readonly bool RequiresActionParameterInMethod;
 
-		public DiscoveredEffectMethod(EffectMethodAttribute attribute, MethodInfo methodInfo)
+		public DiscoveredEffectMethod(
+			Type hostClassType,
+			EffectMethodAttribute attribute,
+			MethodInfo methodInfo)
 		{
 			ParameterInfo[] methodParameters = methodInfo.GetParameters();
 			if (attribute.ActionType == null && methodParameters.Length != 2)
@@ -42,7 +45,7 @@ namespace Fluxor.DependencyInjection
 					$"Effect methods must have a return type of {nameof(Task)}. " + methodInfo.GetClassNameAndMethodName(),
 					nameof(methodInfo));
 
-			HostClassType = methodInfo.DeclaringType;
+			HostClassType = hostClassType;
 			MethodInfo = methodInfo;
 			ActionType = attribute.ActionType ?? methodParameters[0].ParameterType;
 			RequiresActionParameterInMethod = attribute.ActionType == null;

--- a/Source/Fluxor/DependencyInjection/DiscoveredReducerMethod.cs
+++ b/Source/Fluxor/DependencyInjection/DiscoveredReducerMethod.cs
@@ -12,7 +12,7 @@ namespace Fluxor.DependencyInjection
 		public readonly Type ActionType;
 		public readonly bool RequiresActionParameterInMethod;
 
-		public DiscoveredReducerMethod(ReducerMethodAttribute attribute, MethodInfo methodInfo)
+		public DiscoveredReducerMethod(Type hostClassType, ReducerMethodAttribute attribute, MethodInfo methodInfo)
 		{
 			ParameterInfo[] methodParameters = methodInfo.GetParameters();
 			if (attribute.ActionType == null && methodParameters.Length != 2)
@@ -34,7 +34,7 @@ namespace Fluxor.DependencyInjection
 					$"Expected reducer method to return type {methodInfo.ReturnType.FullName}. " + methodInfo.GetClassNameAndMethodName(),
 					nameof(methodInfo));
 
-			HostClassType = methodInfo.DeclaringType;
+			HostClassType = hostClassType;
 			MethodInfo = methodInfo;
 			StateType = methodParameters[0].ParameterType;
 			ActionType = attribute.ActionType ?? methodParameters[1].ParameterType;

--- a/Source/Fluxor/DependencyInjection/ReducerWrapper.cs
+++ b/Source/Fluxor/DependencyInjection/ReducerWrapper.cs
@@ -11,6 +11,7 @@ namespace Fluxor.DependencyInjection
 		TState IReducer<TState>.Reduce(TState state, object action) => Reduce(state, (TAction)action);
 		bool IReducer<TState>.ShouldReduceStateForAction(object action) => action is TAction;
 
+		public ReducerWrapper() { }
 		public ReducerWrapper(object reducerHostInstance, DiscoveredReducerMethod discoveredReducerMethod)
 		{
 			Reduce =

--- a/Source/Fluxor/DependencyInjection/TypeAndMethodInfo.cs
+++ b/Source/Fluxor/DependencyInjection/TypeAndMethodInfo.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Reflection;
+
+namespace Fluxor.DependencyInjection
+{
+	internal struct TypeAndMethodInfo
+	{
+		public readonly Type Type;
+		public readonly MethodInfo MethodInfo;
+
+		public TypeAndMethodInfo(Type type, MethodInfo methodInfo)
+		{
+			Type = type ?? throw new ArgumentNullException(nameof(type));
+			MethodInfo = methodInfo ?? throw new ArgumentNullException(nameof(methodInfo));
+		}
+	}
+}

--- a/Source/Fluxor/Effect.cs
+++ b/Source/Fluxor/Effect.cs
@@ -16,14 +16,10 @@ namespace Fluxor
 		/// <summary>
 		/// <see cref="IEffect.ShouldReactToAction(object)"/>
 		/// </summary>
-		public bool ShouldReactToAction(object action)
-		{
-			return action is TTriggerAction;
-		}
+		public bool ShouldReactToAction(object action) =>
+			action is TTriggerAction;
 
-		Task IEffect.HandleAsync(object action, IDispatcher dispatcher)
-		{
-			return HandleAsync((TTriggerAction)action, dispatcher);
-		}
+		Task IEffect.HandleAsync(object action, IDispatcher dispatcher) =>
+			HandleAsync((TTriggerAction)action, dispatcher);
 	}
 }

--- a/Source/Fluxor/Store.cs
+++ b/Source/Fluxor/Store.cs
@@ -175,7 +175,9 @@ namespace Fluxor
 		private void TriggerEffects(object action)
 		{
 			var recordedExceptions = new List<Exception>();
-			var effectsToExecute = Effects.Where(x => x.ShouldReactToAction(action));
+			var effectsToExecute = Effects
+				.Where(x => x.ShouldReactToAction(action))
+				.ToArray();
 			var executedEffects = new List<Task>();
 
 			Action<Exception> collectExceptions = e =>

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/DiscoverGenericEffectClassesTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/DiscoverGenericEffectClassesTests.cs
@@ -1,0 +1,38 @@
+﻿using Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests.SupportFiles;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests
+{
+	public class DiscoverGenericEffectClassesTests
+	{
+		private readonly IServiceProvider ServiceProvider;
+		private readonly IStore Store;
+		private readonly InvokeCountService InvokeCountService;
+
+		[Fact]
+		public void WhenActionIsDispatched_ThenGenericEffectClassIsExecuted()
+		{
+			Assert.Equal(0, InvokeCountService.GetCount());
+			Store.Dispatch(new TestAction());
+			Assert.Equal(1, InvokeCountService.GetCount());
+		}
+
+		public DiscoverGenericEffectClassesTests()
+		{
+			InvokeCountService = new InvokeCountService();
+			var services = new ServiceCollection();
+			services.AddScoped(_ => InvokeCountService);
+			services.AddFluxor(x => x
+				.ScanAssemblies(GetType().Assembly)
+				.AddMiddleware<IsolatedTests>());
+
+			ServiceProvider = services.BuildServiceProvider();
+			Store = ServiceProvider.GetRequiredService<IStore>();
+
+			Store.InitializeAsync().Wait();
+		}
+
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/InvokeCountService.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/InvokeCountService.cs
@@ -1,0 +1,13 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests.SupportFiles
+{
+	public class InvokeCountService
+	{
+		private int Count;
+
+		public int GetCount() => Count;
+		public void IncrementCount()
+		{
+			Count++;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/IsolatedTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/IsolatedTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests.SupportFiles
+{
+	public class IsolatedTests : Middleware
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/TestAction.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/TestAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests.SupportFiles
+{
+	public class TestAction
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/TestGenericEffectClass.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectClassesTests/SupportFiles/TestGenericEffectClass.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectClassesTests.SupportFiles
+{
+	public class TestGenericEffectClass : AbstractTestGenericEffectClass<TestAction>
+	{
+		public TestGenericEffectClass(InvokeCountService invokeCountService) : base(invokeCountService)
+		{
+		}
+	}
+
+	public abstract class AbstractTestGenericEffectClass<T> : Effect<T>
+	{
+		private readonly InvokeCountService InvokeCountService;
+
+		protected AbstractTestGenericEffectClass(InvokeCountService invokeCountService)
+		{
+			InvokeCountService = invokeCountService;
+		}
+
+		protected override Task HandleAsync(T action, IDispatcher dispatcher)
+		{
+			InvokeCountService.IncrementCount();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/DiscoverGenericEffectClassesWithActionInMethodSignatureTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/DiscoverGenericEffectClassesWithActionInMethodSignatureTests.cs
@@ -1,0 +1,38 @@
+﻿using Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests.SupportFiles;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests
+{
+	public class DiscoverGenericEffectMethodsWithActionInMethodSignatureTests
+	{
+		private readonly IServiceProvider ServiceProvider;
+		private readonly IStore Store;
+		private readonly InvokeCountService InvokeCountService;
+
+		[Fact]
+		public void WhenActionIsDispatched_ThenGenericEffectClassIsExecuted()
+		{
+			Assert.Equal(0, InvokeCountService.GetCount());
+			Store.Dispatch(new TestAction());
+			Assert.Equal(1, InvokeCountService.GetCount());
+		}
+
+		public DiscoverGenericEffectMethodsWithActionInMethodSignatureTests()
+		{
+			InvokeCountService = new InvokeCountService();
+			var services = new ServiceCollection();
+			services.AddScoped(_ => InvokeCountService);
+			services.AddFluxor(x => x
+				.ScanAssemblies(GetType().Assembly)
+				.AddMiddleware<IsolatedTests>());
+
+			ServiceProvider = services.BuildServiceProvider();
+			Store = ServiceProvider.GetRequiredService<IStore>();
+
+			Store.InitializeAsync().Wait();
+		}
+
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/InvokeCountService.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/InvokeCountService.cs
@@ -1,0 +1,13 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests.SupportFiles
+{
+	public class InvokeCountService
+	{
+		private int Count;
+
+		public int GetCount() => Count;
+		public void IncrementCount()
+		{
+			Count++;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/IsolatedTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/IsolatedTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests.SupportFiles
+{
+	public class IsolatedTests : Middleware
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestAction.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests.SupportFiles
+{
+	public class TestAction
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
@@ -19,7 +19,7 @@ namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.Discove
 		}
 
 		[EffectMethod]
-		public static Task HandleAsync(T action, IDispatcher dispatcher)
+		public Task HandleAsync(T action, IDispatcher dispatcher)
 		{
 			InvokeCountService.IncrementCount();
 			return Task.CompletedTask;

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
@@ -19,7 +19,7 @@ namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.Discove
 		}
 
 		[EffectMethod]
-		public Task HandleAsync(T action, IDispatcher dispatcher)
+		public Task HandleTheActionAsync(T action, IDispatcher dispatcher)
 		{
 			InvokeCountService.IncrementCount();
 			return Task.CompletedTask;

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/EffectDiscoveryTests/DiscoverGenericEffectMethodsWithActionInMethodSignatureTests/SupportFiles/TestGenericEffectClass.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading.Tasks;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.EffectDiscoveryTests.DiscoverGenericEffectMethodsWithActionInMethodSignatureTests.SupportFiles
+{
+	public class TestGenericEffectClass : AbstractTestGenericEffectClass<TestAction>
+	{
+		public TestGenericEffectClass(InvokeCountService invokeCountService) : base(invokeCountService)
+		{
+		}
+	}
+
+	public abstract class AbstractTestGenericEffectClass<T> 
+	{
+		private readonly InvokeCountService InvokeCountService;
+
+		protected AbstractTestGenericEffectClass(InvokeCountService invokeCountService)
+		{
+			InvokeCountService = invokeCountService;
+		}
+
+		[EffectMethod]
+		public static Task HandleAsync(T action, IDispatcher dispatcher)
+		{
+			InvokeCountService.IncrementCount();
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/DiscoverGenericReducerClassesTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/DiscoverGenericReducerClassesTests.cs
@@ -1,0 +1,37 @@
+﻿using Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests
+{
+	public class DiscoverGenericReducerClassesTests
+	{
+		private readonly IServiceProvider ServiceProvider;
+		private readonly IStore Store;
+		private readonly IState<TestState> State;
+
+		[Fact]
+		public void WhenActionIsDispatched_ThenReducerWithActionInMethodSignatureIsExecuted()
+		{
+			Assert.False(State.Value.ReducerWasExecuted);
+			Store.Dispatch(new TestAction());
+			Assert.True(State.Value.ReducerWasExecuted);
+		}
+
+		public DiscoverGenericReducerClassesTests()
+		{
+			var services = new ServiceCollection();
+			services.AddFluxor(x => x
+				.ScanAssemblies(GetType().Assembly)
+				.AddMiddleware<IsolatedTests>());
+
+			ServiceProvider = services.BuildServiceProvider();
+			Store = ServiceProvider.GetRequiredService<IStore>();
+			State = ServiceProvider.GetRequiredService<IState<TestState>>();
+
+			Store.InitializeAsync().Wait();
+		}
+	}
+
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/IsolatedTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/IsolatedTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles
+{
+	public class IsolatedTests : Middleware
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestAction.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles
+{
+	public class TestAction
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestFeature.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestFeature.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles
+{
+	public class TestFeature : Feature<TestState>
+	{
+		public override string GetName() => "Test";
+		protected override TestState GetInitialState() => new TestState(reducerWasExecuted: false);
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestGenericReducerClass.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestGenericReducerClass.cs
@@ -1,0 +1,12 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles
+{
+	public class TestGenericReducerClass : AbstractTestGenericReducerClass<TestAction>
+	{
+	}
+
+	public abstract class AbstractTestGenericReducerClass<TAction> : Reducer<TestState, TAction>
+	{
+		public override TestState Reduce(TestState state, TAction action) =>
+			new TestState(reducerWasExecuted: true);
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestState.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducerClassesTests/SupportFiles/TestState.cs
@@ -1,0 +1,12 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducerClassesTests.SupportFiles
+{
+	public class TestState
+	{
+		public bool ReducerWasExecuted { get; private set; }
+
+		public TestState(bool reducerWasExecuted)
+		{
+			ReducerWasExecuted = reducerWasExecuted;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/DiscoverGenericReducersWithActionInMethodSignatureTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/DiscoverGenericReducersWithActionInMethodSignatureTests.cs
@@ -1,0 +1,36 @@
+﻿using Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests
+{
+	public class DiscoverGenericReducersWithActionInMethodSignatureTests
+	{
+		private readonly IServiceProvider ServiceProvider;
+		private readonly IStore Store;
+		private readonly IState<TestState<int>> State;
+
+		[Fact]
+		public void WhenActionIsDispatched_ThenReducerWithActionInMethodSignatureIsExecuted()
+		{
+			Assert.Contains(8, State.Value.Items);
+			Store.Dispatch(new RemoveItemAction<int>(8));
+			Assert.DoesNotContain(8, State.Value.Items);
+		}
+
+		public DiscoverGenericReducersWithActionInMethodSignatureTests()
+		{
+			var services = new ServiceCollection();
+			services.AddFluxor(x => x
+				.ScanAssemblies(GetType().Assembly)
+				.AddMiddleware<IsolatedTests>());
+
+			ServiceProvider = services.BuildServiceProvider();
+			Store = ServiceProvider.GetRequiredService<IStore>();
+			State = ServiceProvider.GetRequiredService<IState<TestState<int>>>();
+
+			Store.InitializeAsync().Wait();
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/IsolatedTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/IsolatedTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
+{
+	public class IsolatedTests : Middleware
+	{
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/RemoveItemAction.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/RemoveItemAction.cs
@@ -1,0 +1,12 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
+{
+	public class RemoveItemAction<T>
+	{
+		public readonly T Item;
+
+		public RemoveItemAction(T item)
+		{
+			Item = item;
+		}
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestFeature.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestFeature.cs
@@ -1,0 +1,9 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
+{
+	public class TestFeature : Feature<TestState<int>>
+	{
+		public override string GetName() => "Test";
+		protected override TestState<int> GetInitialState() =>
+			new TestState<int>(new int[] { 1, 2, 3, 5, 8, 13 });
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
@@ -1,8 +1,15 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
 {
-	public class TestReducers<T>
+	public class TestIntReducer: AbstractTestReducers<int>
+	{
+
+	}
+
+	public abstract class AbstractTestReducers<T>
+		where T : IEquatable<T>
 	{
 		[ReducerMethod]
 		public static TestState<T> ReduceTestAction(TestState<T> state, RemoveItemAction<T> action) =>

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
@@ -1,0 +1,11 @@
+﻿using System.Linq;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
+{
+	public class TestReducers<T>
+	{
+		[ReducerMethod]
+		public static TestState<T> ReduceTestAction(TestState<T> state, RemoveItemAction<T> action) =>
+			new TestState<T>(state.Items.Where(x => !x.Equals(action.Item)).ToArray());
+	}
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestReducers.cs
@@ -5,14 +5,13 @@ namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.Discov
 {
 	public class TestIntReducer: AbstractTestReducers<int>
 	{
-
 	}
 
 	public abstract class AbstractTestReducers<T>
 		where T : IEquatable<T>
 	{
 		[ReducerMethod]
-		public static TestState<T> ReduceTestAction(TestState<T> state, RemoveItemAction<T> action) =>
+		public static TestState<T> ReduceRemoveItemAction(TestState<T> state, RemoveItemAction<T> action) =>
 			new TestState<T>(state.Items.Where(x => !x.Equals(action.Item)).ToArray());
 	}
 }

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestState.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/ReducerDiscoveryTests/DiscoverGenericReducersWithActionInMethodSignatureTests/SupportFiles/TestState.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fluxor.UnitTests.DependencyInjectionTests.ReducerDiscoveryTests.DiscoverGenericReducersWithActionInMethodSignatureTests.SupportFiles
+{
+	public class TestState<T>
+	{
+		public T[] Items;
+
+		public TestState(IEnumerable<T> items)
+		{
+			Items = items.ToArray();
+		}
+	}
+}


### PR DESCRIPTION
 * Added support for declaring `[ReducerMethod]` on generic classes

```c#
public class TestIntReducer: AbstractGenericStateReducers<int>
{
}

public class TestStringReducer: AbstractGenericStateReducers<string>
{
}

public abstract class AbstractGenericStateReducers<T>
	where T : IEquatable<T>
{
	[ReducerMethod]
	public static TestState<T> ReduceRemoveItemAction(TestState<T> state, RemoveItemAction<T> action) =>
		new TestState<T>(state.Items.Where(x => !x.Equals(action.Item)).ToArray());
}
```

 * Added support for declaring `[EffectMethod]` on generic classes

```c#
public class GenericEffectClassForMyAction : AbstractGenericEffectClass<MyAction>
{
	public GenericEffectClassForMyAction(SomeService someService) : base(someService)
	{
	}
}

public class GenericEffectClassForAnotherAction : AbstractGenericEffectClass<AnotherAction>
{
	public GenericEffectClassForAnotherAction(SomeService someService) : base(someService)
	{
	}
}

public abstract class AbstractGenericEffectClass<T> 
{
	private readonly ISomeService SomeService;

	protected AbstractGenericEffectClass(ISomeService someService)
	{
		SomeService = someService;
	}

	[EffectMethod]
	public Task HandleTheActionAsync(T action, IDispatcher dispatcher)
	{
		return SomeService.DoSomethingAsync(action);
	}
}
```