### PR TITLE
Delay state initialisation so derived classe can use ctor parameters

### DIFF
--- a/Source/Fluxor/Feature.cs
+++ b/Source/Fluxor/Feature.cs
@@ -45,7 +45,6 @@ namespace Fluxor
 		public Feature()
 		{
 			TriggerStateChangedCallbacksThrottler = new ThrottledInvoker(TriggerStateChangedCallbacks);
-			State = GetInitialState();
 		}
 
 		private EventHandler untypedStateChanged;
@@ -84,7 +83,12 @@ namespace Fluxor
 		/// <see cref="IFeature{TState}.State"/>
 		public virtual TState State
 		{
-			get => _State;
+			get
+			{
+				if (_State == null)
+					State = GetInitialState();
+				return _State;
+			}
 			protected set
 			{
 				SpinLock.ExecuteLocked(() =>

--- a/Tests/Fluxor.UnitTests/FeatureTests/LazyStateInitializationTests.cs
+++ b/Tests/Fluxor.UnitTests/FeatureTests/LazyStateInitializationTests.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Fluxor.UnitTests.FeatureTests.SupportFiles;
+using Xunit;
+
+namespace Fluxor.UnitTests.FeatureTests
+{
+    public class LazyStateInitializationTests
+    {
+        [Fact]
+        public void WhenAFeatureIsConstructed_ThenStateTheInitialStateIsNotSet()
+        {
+            var count = 0;
+            var feature = new FeatureWithDependency(() => DateTime.MaxValue.Subtract(TimeSpan.FromDays(count++)));
+
+            Assert.NotNull(feature);
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
+        public void WhenStateIsAccessedMultipleTimes_ThenTheStateIsOnlyInitialisedOnce()
+        {
+            var count = 0;
+            var feature = new FeatureWithDependency(() => DateTime.MaxValue.Subtract(TimeSpan.FromDays(count++)));
+
+            for (var i = 0; i < 10; i++)
+                Assert.Equal(DateTime.MaxValue, feature.State.Now);
+
+            Assert.Equal(1, count);
+        }
+    }
+}

--- a/Tests/Fluxor.UnitTests/FeatureTests/SupportFiles/FeatureWithDependency.cs
+++ b/Tests/Fluxor.UnitTests/FeatureTests/SupportFiles/FeatureWithDependency.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Fluxor.UnitTests.FeatureTests.SupportFiles
+{
+    public class State
+    {
+        public DateTime Now { get; }
+
+        public State(DateTime now)
+        {
+            Now = now;
+        }
+
+    }
+
+    public class FeatureWithDependency : Feature<State>
+    {
+        readonly Func<DateTime> _NowGetter;
+
+        public override string GetName() => nameof(FeatureWithDependency);
+
+        public FeatureWithDependency(Func<DateTime> nowGetter)
+        {
+            _NowGetter = nowGetter;
+        }
+
+        protected override State GetInitialState()
+        {
+            return new State(_NowGetter());
+        }
+    }
+}


### PR DESCRIPTION
Ran into this issue, while I can create a feature with constructor parameters, I cannot use these parameters to initialise the state as the state is created before the derived constructor has had a chance to run. This sorts the issue by delaying the state initialisation until it is used for the first time.