### PR TITLE
Add the ability to scan assemblies with namespace restriction.

### DIFF
--- a/Source/Fluxor/DependencyInjection/Options.cs
+++ b/Source/Fluxor/DependencyInjection/Options.cs
@@ -54,10 +54,12 @@ namespace Fluxor.DependencyInjection
 		/// <param name="assemblyToScan">The assembly to be scanned</param>
 		/// <param name="namespace">The namespace in which to discover features/effects/reducers.</param>
 		/// <returns>Options</returns>
-		public Options ScanAssembly(Assembly assemblyToScan, string @namespace = null)
+		public Options ScanAssembly(Assembly assemblyToScan, string @namespace)
 		{
 			if (assemblyToScan == null)
 				throw new ArgumentNullException(nameof(assemblyToScan));
+			if (@namespace == null)
+				throw new ArgumentNullException(nameof(@namespace));
 
 			AssembliesToScan = AssembliesToScan.Append(new AssemblyScanSettings(assemblyToScan, @namespace)).ToArray();
 

--- a/Source/Fluxor/DependencyInjection/Options.cs
+++ b/Source/Fluxor/DependencyInjection/Options.cs
@@ -49,6 +49,22 @@ namespace Fluxor.DependencyInjection
 		}
 
 		/// <summary>
+		/// Enables automatic discovery of features/effects/reducers
+		/// </summary>
+		/// <param name="assemblyToScan">The assembly to be scanned</param>
+		/// <param name="namespace">The namespace in which to discover features/effects/reducers.</param>
+		/// <returns>Options</returns>
+		public Options ScanAssembly(Assembly assemblyToScan, string @namespace = null)
+		{
+			if (assemblyToScan == null)
+				throw new ArgumentNullException(nameof(assemblyToScan));
+
+			AssembliesToScan = AssembliesToScan.Append(new AssemblyScanSettings(assemblyToScan, @namespace)).ToArray();
+
+			return this;
+		}
+
+		/// <summary>
 		/// Enables the developer to specify a class that implements <see cref="IMiddleware"/>
 		/// which should be injected into the <see cref="IStore.AddMiddleware(IMiddleware)"/> method
 		/// after dependency injection has completed.


### PR DESCRIPTION
I want the ability to conditionally load feature/effects/reducers, so I can enable/disable entire features at a higher level, without having to make the features aware of it. I can do this quite simply by leveraging the namespace filtering capabilities in Fluxor, but these are not exposed. This PR addresses it by exposing this capability with the new method `ScanAssembly`.

Example of the usage:

```
serviceCollection.AddFluxor(options => {
    options.ScanAssembly(myAssembly, typeof(Feature1).Namespace);

    if (condition) {
        options.ScanAssembly(myAssembly, typeof(Feature2).Namespace);
        options.ScanAssembly(myAssembly, typeof(Feature3).Namespace);
    } 
}
```