### PR TITLE
Upgrade unit tests to .NET 6

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -1,5 +1,8 @@
 # Releases
 
+## New in 4.2.1
+ * Support .NET 6
+
 ## New in 4.2
  * New `[FeatureState]` attribute to avoid having to create `Feature<T>` descendant classes. ([#204](https://github.com/mrpmorris/Fluxor/issues/204))
  * Add `FluxorOptions.ScanTypes` to allow scanning of specified classes. ([#214](https://github.com/mrpmorris/Fluxor/issues/214))

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,9 +2,9 @@
 
 	<PropertyGroup>
 
-		<Version>4.2.0-Beta</Version>
-		<AssemblyVersion>4.2.0.0</AssemblyVersion>
-		<FileVersion>4.2.0.0</FileVersion>
+		<Version>4.2.1</Version>
+		<AssemblyVersion>4.2.1.0</AssemblyVersion>
+		<FileVersion>4.2.1.0</FileVersion>
 
 		<Authors>Peter Morris</Authors>
 		<Company />

--- a/Source/Fluxor.Blazor.Web.ReduxDevTools/Fluxor.Blazor.Web.ReduxDevTools.csproj
+++ b/Source/Fluxor.Blazor.Web.ReduxDevTools/Fluxor.Blazor.Web.ReduxDevTools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
 
     <Product>ReduxDevTools for Fluxor Blazor (Web)</Product>

--- a/Source/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
+++ b/Source/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RazorLangVersion>3.0</RazorLangVersion>
 
     <Product>Fluxor for Blazor (Web)</Product>

--- a/Source/Fluxor/Fluxor.csproj
+++ b/Source/Fluxor/Fluxor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <Product>Fluxor</Product>
     <Description>A zero boilerplate Redux/Flux framework for .NET</Description>

--- a/Tests/Fluxor.Blazor.Web.UnitTests/Fluxor.Blazor.Web.UnitTests.csproj
+++ b/Tests/Fluxor.Blazor.Web.UnitTests/Fluxor.Blazor.Web.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Tests/Fluxor.UnitTests/Fluxor.UnitTests.csproj
+++ b/Tests/Fluxor.UnitTests/Fluxor.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR will upgrade unit tests to use .NET 6, so having only the latest version of the .NET SDK installed is enough to work with the solution.