### PR TITLE
Fix WeatherState class in Effects tutorial

### DIFF
--- a/Tutorials/02-Blazor/02B-EffectsTutorial/README.md
+++ b/Tutorials/02-Blazor/02B-EffectsTutorial/README.md
@@ -18,11 +18,13 @@ This tutorial will recreate the `Fetch data` page in a standard Blazor app.
 - Create a new state class to hold the state for this use case.
 
 ```c#
+[FeatureState]
 public class WeatherState
 {
   public bool IsLoading { get; }
   public IEnumerable<WeatherForecast> Forecasts { get; }
 
+  private WeatherState() { }
   public WeatherState(bool isLoading, IEnumerable<WeatherForecast> forecasts)
   {
     IsLoading = isLoading;


### PR DESCRIPTION
This pull request adds a missing `FeatureState` attribute and an empty ctor to the "Effects" tutorial's `WeatherState` class' code.

By merging this PR it is possible for a new user to finish the tutorial without runtime errors.

These changes already exist in the [actual code file](https://github.com/mrpmorris/Fluxor/blob/master/Tutorials/02-Blazor/02B-EffectsTutorial/EffectsTutorial/Client/Store/WeatherUseCase/WeatherState.cs), but were missing from the tutorial documentation.