### PR TITLE
Added support for value-type features, dispatch ext, and unit tests

### DIFF
--- a/Source/Fluxor/DependencyInjection/FeatureStateInfo.cs
+++ b/Source/Fluxor/DependencyInjection/FeatureStateInfo.cs
@@ -35,13 +35,17 @@ namespace Fluxor.DependencyInjection
 		private Func<object> CreateFactoryFromParameterlessConstructor(
 			FeatureStateAttribute featureStateAttribute)
 		{
-			ConstructorInfo constructor = StateType.GetConstructor(
+			if (StateType.IsValueType)
+				return () => Activator.CreateInstance(StateType);
+
+			ConstructorInfo constructor =
+				StateType.GetConstructor(
 				BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
 				binder: null,
 				CallingConventions.HasThis,
 				types: Array.Empty<Type>(),
 				modifiers: null);
-			
+
 			if (constructor is null)
 				throw new ArgumentException(
 					message: 

--- a/Source/Fluxor/Extensions/IDispatcherExtesions.cs
+++ b/Source/Fluxor/Extensions/IDispatcherExtesions.cs
@@ -1,0 +1,14 @@
+﻿namespace Fluxor
+{
+	public static class IDispatcherExtesions
+	{
+		/// <summary>
+		/// Dispatches an action to all features added to the store and ensures all effects with a regstered
+		/// interest in the action type are notified.
+		/// </summary>
+		/// <typeparam name="TAction">The action type to dispatch to all features</typeparam>
+		public static void Dispatch<TAction>(
+			this IDispatcher dispatcher) where TAction : new() =>
+			dispatcher?.Dispatch(new TAction());
+	}
+}

--- a/Source/Fluxor/FeatureStateAttribute.cs
+++ b/Source/Fluxor/FeatureStateAttribute.cs
@@ -2,8 +2,10 @@
 
 namespace Fluxor
 {
-	[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
-	public class FeatureStateAttribute : Attribute
+	[AttributeUsage(
+		 AttributeTargets.Class | AttributeTargets.Struct,
+		AllowMultiple = false, Inherited = false)]
+	public sealed class FeatureStateAttribute : Attribute
 	{
 		public string Name { get; set; }
 		public string CreateInitialStateMethodName { get; set; }

--- a/Tests/Fluxor.UnitTests/ActionSubscriberTests/SubscribeToActionTests/SubscribeToActionTests.cs
+++ b/Tests/Fluxor.UnitTests/ActionSubscriberTests/SubscribeToActionTests/SubscribeToActionTests.cs
@@ -97,7 +97,6 @@ namespace Fluxor.UnitTests.ActionSubscriberTests.SubscribeToActionTests
 			Assert.Same(dispatchedDescendantAction, receivedDescendantAction);
 		}
 
-
 		[Fact]
 		public void WhenActionIsDispatched_ThenNotifiesMultipleSubscribers()
 		{
@@ -129,6 +128,17 @@ namespace Fluxor.UnitTests.ActionSubscriberTests.SubscribeToActionTests
 
 			Assert.Same(dispatchedAction, actionReceivedBySubscriber1);
 			Assert.Null(actionReceivedBySubscriber2);
+		}
+
+		[Fact]
+		public void WhenGenericActionIsDispatched_ThenNotifiesSubscriber()
+        {
+			TestReadonlyRecordStructAction? receivedAction = null;
+
+			Subject.SubscribeToAction<TestReadonlyRecordStructAction>(this, x => receivedAction = x);
+			Dispatcher.Dispatch<TestReadonlyRecordStructAction>();
+
+			Assert.Equal(default(TestReadonlyRecordStructAction), receivedAction);
 		}
 	}
 }

--- a/Tests/Fluxor.UnitTests/ActionSubscriberTests/SubscribeToActionTests/SupportFiles/TestReadonlyRecordStructAction.cs
+++ b/Tests/Fluxor.UnitTests/ActionSubscriberTests/SubscribeToActionTests/SupportFiles/TestReadonlyRecordStructAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.ActionSubscriberTests.SubscribeToActionTests.SupportFiles
+{
+    public readonly record struct TestReadonlyRecordStructAction
+    {
+    }
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/DiscoverFeatureStateAttributeTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/DiscoverFeatureStateAttributeTests.cs
@@ -51,6 +51,19 @@ namespace Fluxor.UnitTests.DependencyInjectionTests.FeatureDiscoveryTests.Discov
 		}
 
 		[Fact]
+		public void WhenFeatureStateAttributeHasParameterValues_ThenStructFeatureIsCreatedWithValues()
+		{
+			IStore store = CreateStore(typeof(StructStateWithParameterizedFeatureStateAttribute));
+			Assert.Single(store.Features);
+
+			IFeature feature = store.Features.First().Value;
+			Assert.Equal("ParameterizedName", feature.GetName());
+			Assert.Equal(42, feature.MaximumStateChangedNotificationsPerSecond);
+			Assert.Equal(typeof(StructStateWithParameterizedFeatureStateAttribute), feature.GetStateType());
+			Assert.NotNull(feature.GetState());
+		}
+
+		[Fact]
 		public void WhenFeatureHasCreateInitialStateMethodName_ThenMethodIsInvokedToCreateDefaultState()
 		{
 			IStore store = CreateStore(typeof(StateWithStaticFactoryMethod));

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/DiscoverFeatureStateAttributeTests.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/DiscoverFeatureStateAttributeTests.cs
@@ -25,6 +25,19 @@ namespace Fluxor.UnitTests.DependencyInjectionTests.FeatureDiscoveryTests.Discov
 		}
 
 		[Fact]
+		public void WhenFeatureStateAttibuteHasNoParameterValues_ThenStructFeatureIsCreatedWithDefaultValues()
+        {
+			IStore store = CreateStore(typeof(StructStateWithParameterlessFeatureStateAttribute));
+			Assert.Single(store.Features);
+
+			IFeature feature = store.Features.First().Value;
+			Assert.Equal(typeof(StructStateWithParameterlessFeatureStateAttribute).FullName, feature.GetName());
+			Assert.Equal(0, feature.MaximumStateChangedNotificationsPerSecond);
+			Assert.Equal(typeof(StructStateWithParameterlessFeatureStateAttribute), feature.GetStateType());
+			Assert.NotNull(feature.GetState());
+		}
+
+		[Fact]
 		public void WhenFeatureStateAttributeHasParameterValues_ThenFeatureIsCreatedWithParameterValues()
 		{
 			IStore store = CreateStore(typeof(StateWithParameterizedFeatureStateAttribute));

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/SupportFiles/StructStateWithParameterizedFeatureStateAttribute.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/SupportFiles/StructStateWithParameterizedFeatureStateAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.FeatureDiscoveryTests.DiscoverFeatureStateAttributeTests.SupportFiles
+{
+    [FeatureState(Name = "ParameterizedName", MaximumStateChangedNotificationsPerSecond = 42)]
+    public readonly record struct StructStateWithParameterizedFeatureStateAttribute(
+        string Name,
+        int MaximumStateChangedNotificationsPerSecond);
+}

--- a/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/SupportFiles/StructStateWithParameterlessFeatureStateAttribute.cs
+++ b/Tests/Fluxor.UnitTests/DependencyInjectionTests/FeatureDiscoveryTests/DiscoverFeatureStateAttributeTests/SupportFiles/StructStateWithParameterlessFeatureStateAttribute.cs
@@ -1,0 +1,7 @@
+﻿namespace Fluxor.UnitTests.DependencyInjectionTests.FeatureDiscoveryTests.DiscoverFeatureStateAttributeTests.SupportFiles
+{
+    [FeatureState]
+    public readonly record struct StructStateWithParameterlessFeatureStateAttribute
+    {
+    }
+}

--- a/Tests/Fluxor.UnitTests/Fluxor.UnitTests.csproj
+++ b/Tests/Fluxor.UnitTests/Fluxor.UnitTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
In this PR:

- Added `Disptach<TAction>()` extension method for `new T()` scenarios
- Added support for value-type features
- Added new unit tests