### PR TITLE
Out of the box support for IAsyncDisposable descendant components

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorLayout.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorLayout.cs
@@ -1,6 +1,7 @@
 ﻿using Fluxor.UnsupportedClasses;
 using Microsoft.AspNetCore.Components;
 using System;
+using System.Threading.Tasks;
 
 namespace Fluxor.Blazor.Web.Components
 {
@@ -8,7 +9,7 @@ namespace Fluxor.Blazor.Web.Components
 	/// A layout that auto-subscribes to state changes on all <see cref="IStateChangedNotifier"/> properties
 	/// and ensures <see cref="LayoutComponentBase.StateHasChanged"/> is called
 	/// </summary>
-	public abstract class FluxorLayout : LayoutComponentBase, IDisposable
+	public abstract class FluxorLayout : LayoutComponentBase, IDisposable, IAsyncDisposable
 	{
 		[Inject]
 		private IActionSubscriber ActionSubscriber { get; set; }
@@ -62,6 +63,18 @@ namespace Fluxor.Blazor.Web.Components
 				Disposed = true;
 			}
 		}
+		/// <summary>
+		/// Disposes of the component and unsubscribes from any state
+		/// </summary>
+		public async ValueTask DisposeAsync()
+		{
+			if (!Disposed)
+			{
+				await DisposeAsync(true);
+				GC.SuppressFinalize(this);
+				Disposed = true;
+			}
+		}
 
 		/// <summary>
 		/// Subscribes to state properties
@@ -75,7 +88,7 @@ namespace Fluxor.Blazor.Web.Components
 			});
 		}
 
-		protected virtual void Dispose(bool disposing)
+		private void InternalDispose(bool disposing)
 		{
 			if (disposing)
 			{
@@ -85,6 +98,15 @@ namespace Fluxor.Blazor.Web.Components
 				StateSubscription.Dispose();
 				ActionSubscriber?.UnsubscribeFromAllActions(this);
 			}
+		}
+		protected virtual void Dispose(bool disposing)
+		{
+			InternalDispose(disposing);
+		}
+		protected virtual ValueTask DisposeAsync(bool disposing)
+		{
+			InternalDispose(disposing);
+			return default;
 		}
 	}
 }

--- a/Source/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorComponentTests/DisposeTests.cs
+++ b/Source/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorComponentTests/DisposeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Fluxor.Blazor.Web.UnitTests.SupportFiles;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorComponentTests
@@ -15,6 +16,16 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorComponentTests
 		{
 			StateSubject.ExecuteOnInitialized();
 			StateSubject.Dispose();
+
+			Assert.Equal(1, MockState1.UnsubscribeCount);
+			Assert.Equal(1, MockState2.UnsubscribeCount);
+		}
+
+		[Fact]
+		public async Task WhenDisposedAsync_ThenUnsubscribesFromStateProperties()
+		{
+			StateSubject.ExecuteOnInitialized();
+			await StateSubject.DisposeAsync();
 
 			Assert.Equal(1, MockState1.UnsubscribeCount);
 			Assert.Equal(1, MockState2.UnsubscribeCount);
@@ -38,6 +49,23 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorComponentTests
 		}
 
 		[Fact]
+		public async Task WhenDisposingAsyncAndBaseOnInitializedWasNotCalled_ThenThrowsNullReferenceException()
+		{
+			string errorMessage = null;
+			var component = new FluxorComponentThatOptionallyCallsBaseOnInitialized();
+			try
+			{
+				component.Test_OnInitialized();
+				await component.DisposeAsync();
+			}
+			catch (NullReferenceException e)
+			{
+				errorMessage = e.Message;
+			}
+			Assert.Equal("Have you forgotten to call base.OnInitialized() in your component?", errorMessage);
+		}
+
+		[Fact]
 		public void WhenBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
 		{
 			var component = new FluxorComponentThatOptionallyCallsBaseOnInitialized
@@ -46,6 +74,16 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorComponentTests
 			};
 			component.Test_OnInitialized();
 			component.Dispose();
+		}
+
+		[Fact]
+		public async Task WhenDisposingAsyncAndBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
+		{
+			var component = new FluxorComponentThatOptionallyCallsBaseOnInitialized {
+				CallBaseOnInitialized = true
+			};
+			component.Test_OnInitialized();
+			await component.DisposeAsync();
 		}
 
 		public DisposeTests()

--- a/Source/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorLayoutTests/DisposeTests.cs
+++ b/Source/Tests/Fluxor.Blazor.Web.UnitTests/Components/FluxorLayoutTests/DisposeTests.cs
@@ -1,5 +1,6 @@
 ﻿using Fluxor.Blazor.Web.UnitTests.SupportFiles;
 using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorLayoutTests
@@ -15,6 +16,16 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorLayoutTests
 		{
 			StateSubject.ExecuteOnInitialized();
 			StateSubject.Dispose();
+
+			Assert.Equal(1, MockState1.UnsubscribeCount);
+			Assert.Equal(1, MockState2.UnsubscribeCount);
+		}
+
+		[Fact]
+		public async Task WhenDisposedAsync_ThenUnsubscribesFromStateProperties()
+		{
+			StateSubject.ExecuteOnInitialized();
+			await StateSubject.DisposeAsync();
 
 			Assert.Equal(1, MockState1.UnsubscribeCount);
 			Assert.Equal(1, MockState2.UnsubscribeCount);
@@ -38,6 +49,23 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorLayoutTests
 		}
 
 		[Fact]
+		public async Task WhenDisposingAsyncAndBaseOnInitializedWasNotCalled_ThenThrowsNullReferenceException()
+		{
+			string errorMessage = null;
+			var layout = new FluxorLayoutThatOptionallyCallsBaseOnInitialized();
+			try
+			{
+				layout.Test_OnInitialized();
+				await layout.DisposeAsync();
+			}
+			catch (NullReferenceException e)
+			{
+				errorMessage = e.Message;
+			}
+			Assert.Equal("Have you forgotten to call base.OnInitialized() in your component?", errorMessage);
+		}
+
+		[Fact]
 		public void WhenBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
 		{
 			var layout = new FluxorLayoutThatOptionallyCallsBaseOnInitialized
@@ -47,6 +75,17 @@ namespace Fluxor.Blazor.Web.UnitTests.Components.FluxorLayoutTests
 			layout.Test_OnInitialized();
 			layout.Dispose();
 		}
+
+		[Fact]
+		public async Task WhenDisposingAsyncAndBaseOnInitializedWasCalled_ThenDoesNotThrowAnException()
+		{
+			var layout = new FluxorLayoutThatOptionallyCallsBaseOnInitialized {
+				CallBaseOnInitialized = true
+			};
+			layout.Test_OnInitialized();
+			await layout.DisposeAsync();
+		}
+
 		public DisposeTests()
 		{
 			MockState1 = new MockState<int>();


### PR DESCRIPTION
This PR:
-  Resolves #324 
- Ensures that however the descendants of `FluxorComponent` and `FluxorLayout` are disposed, the state and action subscriptions are disposed as well.
- `FluxorComponent` and `FluxorLayout` now implement `IAsyncDisposable`
- Adds unit tests for the above
