### PR TITLE
Fixes issue with RestoreState (Fixes #347)

### DIFF
--- a/Source/Lib/Fluxor/Feature.cs
+++ b/Source/Lib/Fluxor/Feature.cs
@@ -87,6 +87,7 @@ namespace Fluxor
 					if (stateHasChanged)
 					{
 						_State = value;
+						HasInitialState = true;
 						TriggerStateChangedCallbacksThrottler.Invoke(MaximumStateChangedNotificationsPerSecond);
 					}
 				});

--- a/Source/Tests/Fluxor.UnitTests/FeatureTests/FeatureTests.cs
+++ b/Source/Tests/Fluxor.UnitTests/FeatureTests/FeatureTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxor.UnitTests.FeatureTests
+{
+	public class FeatureTests
+	{
+		private class TestState
+		{
+			public int SomeValue { get; }
+
+			public TestState(int someValue)
+			{
+				SomeValue = someValue;
+			}
+		}
+		
+
+		private class SomeFeature : Feature<TestState>
+		{
+			public override string GetName() => "SomeName";
+
+			protected override TestState GetInitialState() => new TestState(1);
+		}
+
+		[Fact]
+		public void WhenFeatureRestoredStateIsCalledBeforeGettingFeatureState_StateReturnsRestoredState()
+		{
+			IFeature<TestState> feature = new SomeFeature();
+			feature.RestoreState(new TestState(2));
+			TestState featureState = feature.State;
+			Assert.Equal(2, featureState.SomeValue);
+		}
+
+		[Fact]
+		public void WhenFeatureRestoredStateIsCalledAfterGettingFeatureState_StateReturnsRestoredState()
+		{
+			IFeature<TestState> feature = new SomeFeature();
+			TestState featureState = feature.State;
+			feature.RestoreState(new TestState(2));
+			featureState = feature.State;
+			Assert.Equal(2, featureState.SomeValue);
+		}
+
+		[Fact]
+		public void WhenGettingFeatureStateAfterConstruction_StateReturnsInitialState()
+		{
+			IFeature<TestState> feature = new SomeFeature();
+			TestState featureState = feature.State;
+			Assert.Equal(1, featureState.SomeValue);
+		}
+	}
+}

--- a/Source/Tutorials/02-Blazor/02E-ActionSubscriber/FluxorBlazorWeb.ActionSubscriberTutorial/Client/Pages/Customers/Edit.razor
+++ b/Source/Tutorials/02-Blazor/02E-ActionSubscriber/FluxorBlazorWeb.ActionSubscriberTutorial/Client/Pages/Customers/Edit.razor
@@ -5,18 +5,18 @@
 @using CustomerContracts = FluxorBlazorWeb.ActionSubscriberTutorial.Contracts.Customers
 
 <h3>Edit customer</h3>
-@if (EditCustomerDto is null)
+@if (State.Value.IsLoading || State.Value.IsSaving || EditCustomerDto is null)
 {
     if (State.Value.IsLoading)
     {
         <h4>Loading...</h4>
     }
-    if (State.Value.IsSaving)
+    else
     {
         <h4>Saving customer: @EditCustomerDto?.Id @EditCustomerDto?.Name</h4>
     }
 }
-@if (EditCustomerDto is not null)
+else
 {
     <EditForm Model=@EditCustomerDto>
         <DataAnnotationsValidator/>

--- a/Source/Tutorials/02-Blazor/02E-ActionSubscriber/FluxorBlazorWeb.ActionSubscriberTutorial/Client/Pages/Customers/Edit.razor
+++ b/Source/Tutorials/02-Blazor/02E-ActionSubscriber/FluxorBlazorWeb.ActionSubscriberTutorial/Client/Pages/Customers/Edit.razor
@@ -5,18 +5,18 @@
 @using CustomerContracts = FluxorBlazorWeb.ActionSubscriberTutorial.Contracts.Customers
 
 <h3>Edit customer</h3>
-@if (State.Value.IsLoading || State.Value.IsSaving)
+@if (EditCustomerDto is null)
 {
     if (State.Value.IsLoading)
     {
         <h4>Loading...</h4>
     }
-    else
+    if (State.Value.IsSaving)
     {
         <h4>Saving customer: @EditCustomerDto?.Id @EditCustomerDto?.Name</h4>
     }
 }
-else
+@if (EditCustomerDto is not null)
 {
     <EditForm Model=@EditCustomerDto>
         <DataAnnotationsValidator/>


### PR DESCRIPTION
Fixes issue where state restored by RestoreState is overwritte by initial state if RestoreState is called before the Feature's state has been initialized.
We ran into an issue with this behavior when using Fluxor-persist library as RestoreState might be called on Features before the  state from the Features are actually injected in to any page. Regardless of this specific issue, it does not seem right that RestoreState cannot simply called whenever you want to set the state of the feature, but must do so only after having retrieved the state at least once. Obviously I might be mistaken :-)

The PR adds some unit test to verify the behavior of the State property on the Feature class as well.

Thanks for a very nice library - we are very happy users of it, but stumbled in to this issue yesterday :-)