### PR TITLE
Enable SourceLink (Fixes #351)

### DIFF
--- a/Source/Fluxor.sln
+++ b/Source/Fluxor.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C2B1D7B3-E943-4EA3-88B0-94433B49080C}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		Lib\Directory.Build.props = Lib\Directory.Build.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fluxor", "Lib\Fluxor\Fluxor.csproj", "{863909D3-7E81-4240-8C0A-6F57768D28FF}"

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -14,13 +14,18 @@
 
 		<PackageProjectUrl>https://github.com/mrpmorris/Fluxor</PackageProjectUrl>
 		<PackageIconUrl />
-		<RepositoryUrl>https://github.com/mrpmorris/Fluxor</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
+
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<DebugType>embedded</DebugType>
+		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 
 		<AssemblyOriginatorKeyFile>..\..\..\..\..\MrPMorris.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<DelaySign>false</DelaySign>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -30,6 +35,10 @@
 
 	<ItemGroup>
 		<SupportedPlatform Include="browser" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
 	</ItemGroup>
 
 </Project>

--- a/Source/Lib/Directory.Build.props
+++ b/Source/Lib/Directory.Build.props
@@ -24,8 +24,6 @@
 		<SignAssembly>true</SignAssembly>
 		<DelaySign>false</DelaySign>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-
-
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
@mrpmorris can we enable SourceLink on your library?  I'm trying to track down a missing OnInitialized call and it would be helpful to step through the Fluxor code from Visual Studio without having to download the project and reference it as a package reference.

[[NuGet Package Explorer for Fluxor 5.5.0](https://nuget.info/packages/Fluxor.Blazor.Web/5.5.0)](https://nuget.info/packages/Fluxor.Blazor.Web/5.5.0)

I don't know what your CI system is but you will want to trigger the

```xml
<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
```

element from your CI system.  I put it in there how I run it on GitHub Actions but I notice you don't use GitHub Actions and I don't see any build artifacts from other known CI systems.

I've set this up on my SequentialGuid library and you can see the results [here](https://nuget.info/packages/SequentialGuid/4.0.2)