### PR TITLE
Fix ReduceFetchDataResultAction

### DIFF
--- a/Source/Tutorials/01-BasicConcepts/01B-EffectsTutorial/README.md
+++ b/Source/Tutorials/01-BasicConcepts/01B-EffectsTutorial/README.md
@@ -309,8 +309,8 @@ our mock server.
 action into state.
 
 ```c#
-[ReducerMethod(typeof(FetchDataResultAction))]
-public static WeatherState ReduceFetchDataResultAction(WeatherState state) =>
+[ReducerMethod]
+public static WeatherState ReduceFetchDataResultAction(FetchDataResultAction action, WeatherState state) =>
   new WeatherState(
     isLoading: false,
     forecasts: action.Forecasts);


### PR DESCRIPTION
Method signature missing the action, which is needed to reference the Forecasts