### PR TITLE
Fix memory leak when using ActionSubscriber or SubscribeToAction (Fixes #378)

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -1,5 +1,8 @@
 # Releases
 
+## New in 5.7
+* Fixes memory leak when using `ActionSubscriber` or `SubscribeToAction` ([#378](https://github.com/mrpmorris/Fluxor/issues/378))
+
 ## New in 5.6
 * Support .NET 7
 * Ensure StateSelection unsubscribes properly ([#353](https://github.com/mrpmorris/Fluxor/issues/353))

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -96,9 +96,7 @@ namespace Fluxor
 				}
 
 				foreach(object subscription in subscribedInstances)
-				{
 					SubscriptionsForInstance.Remove(subscription);
-				}
 			}
 		}
 	}

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -77,6 +77,11 @@ namespace Fluxor
 				if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
 					return;
 
+				IEnumerable<object> subscribedInstances =
+				    instanceSubscriptions
+					.Select(x => x.Subscriber)
+					.Distinct();
+					
 				IEnumerable<Type> subscribedActionTypes =
 					instanceSubscriptions
 						.Select(x => x.ActionType)
@@ -90,6 +95,12 @@ namespace Fluxor
 					SubscriptionsForType[actionType] = actionTypeSubscriptions
 						.Except(instanceSubscriptions)
 						.ToList();
+				}
+				
+				foreach (object subscription in subscribedInstances)
+				{
+				    if (SubscriptionsForInstance.ContainsKey(subscription))
+					SubscriptionsForInstance.Remove(subscription);
 				}
 			}
 		}

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -1,108 +1,104 @@
-﻿using Fluxor.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace Fluxor
 {
-	internal class ActionSubscriber : IActionSubscriber
-	{
-		private readonly object SyncRoot = new();
-		private readonly Dictionary<object, List<ActionSubscription>> SubscriptionsForInstance = new();
-		private readonly Dictionary<Type, List<ActionSubscription>> SubscriptionsForType = new();
+    internal class ActionSubscriber : IActionSubscriber
+    {
+        private readonly object SyncRoot = new();
+        private readonly Dictionary<object, List<ActionSubscription>> SubscriptionsForInstance = new();
+        private readonly Dictionary<Type, List<ActionSubscription>> SubscriptionsForType = new();
 
+        public IDisposable GetActionUnsubscriberAsIDisposable(object subscriber) =>
+            new DisposableCallback(
+                id: $"{nameof(ActionSubscriber)}.{nameof(GetActionUnsubscriberAsIDisposable)}",
+                action: () => UnsubscribeFromAllActions(subscriber));
 
-		public IDisposable GetActionUnsubscriberAsIDisposable(object subscriber) =>
-			new DisposableCallback(
-				id: $"{nameof(ActionSubscriber)}.{nameof(GetActionUnsubscriberAsIDisposable)}",
-				action: () => UnsubscribeFromAllActions(subscriber));
+        public void Notify(object action)
+        {
+            if (action is null)
+                throw new ArgumentNullException(nameof(action));
 
-		public void Notify(object action)
-		{
-			if (action is null)
-				throw new ArgumentNullException(nameof(action));
+            lock (SyncRoot)
+            {
+                IEnumerable<Action<object>> callbacks =
+                    SubscriptionsForType
+                        .Where(x => x.Key.IsAssignableFrom(action.GetType()))
+                        .SelectMany(x => x.Value)
+                        .Select(x => x.Callback)
+                        .ToArray();
+                foreach (Action<object> callback in callbacks)
+                    callback(action);
+            }
+        }
 
-			lock(SyncRoot)
-			{
-				IEnumerable<Action<object>> callbacks =
-					SubscriptionsForType
-						.Where(x => x.Key.IsAssignableFrom(action.GetType()))
-						.SelectMany(x => x.Value)
-						.Select(x => x.Callback)
-						.ToArray();
-				foreach (Action<object> callback in callbacks)
-					callback(action);
-			}
-		}
+        public void SubscribeToAction<TAction>(object subscriber, Action<TAction> callback)
+        {
+            if (subscriber is null)
+                throw new ArgumentNullException(nameof(subscriber));
+            if (callback is null)
+                throw new ArgumentNullException(nameof(callback));
 
-		public void SubscribeToAction<TAction>(object subscriber, Action<TAction> callback)
-		{
-			if (subscriber is null)
-				throw new ArgumentNullException(nameof(subscriber));
-			if (callback is null)
-				throw new ArgumentNullException(nameof(callback));
+            var subscription = new ActionSubscription(
+                subscriber: subscriber,
+                actionType: typeof(TAction),
+                callback: (object action) => callback((TAction)action));
 
-			var subscription = new ActionSubscription(
-				subscriber: subscriber,
-				actionType: typeof(TAction),
-				callback: (object action) => callback((TAction)action));
+            lock (SyncRoot)
+            {
+                if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
+                {
+                    instanceSubscriptions = new List<ActionSubscription>();
+                    SubscriptionsForInstance[subscriber] = instanceSubscriptions;
+                }
+                instanceSubscriptions.Add(subscription);
 
-			lock(SyncRoot)
-			{
-				if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
-				{
-					instanceSubscriptions = new List<ActionSubscription>();
-					SubscriptionsForInstance[subscriber] = instanceSubscriptions;
-				}
-				instanceSubscriptions.Add(subscription);
+                if (!SubscriptionsForType.TryGetValue(typeof(TAction), out List<ActionSubscription> typeSubscriptions))
+                {
+                    typeSubscriptions = new List<ActionSubscription>();
+                    SubscriptionsForType[typeof(TAction)] = typeSubscriptions;
+                }
+                typeSubscriptions.Add(subscription);
+            };
+        }
 
-				if (!SubscriptionsForType.TryGetValue(typeof(TAction), out List<ActionSubscription> typeSubscriptions))
-				{
-					typeSubscriptions = new List<ActionSubscription>();
-					SubscriptionsForType[typeof(TAction)] = typeSubscriptions;
-				}
-				typeSubscriptions.Add(subscription);
-			};
-		}
+        public void UnsubscribeFromAllActions(object subscriber)
+        {
+            if (subscriber is null)
+                throw new ArgumentNullException(nameof(subscriber));
 
-		public void UnsubscribeFromAllActions(object subscriber)
-		{
-			if (subscriber is null)
-				throw new ArgumentNullException(nameof(subscriber));
+            List<ActionSubscription> instanceSubscriptions;
+            lock (SyncRoot)
+            {
+                if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
+                    return;
 
-			List<ActionSubscription> instanceSubscriptions;
-			lock(SyncRoot)
-			{
-				if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
-					return;
+                IEnumerable<object> subscribedInstances =
+                    instanceSubscriptions
+                    .Select(x => x.Subscriber)
+                    .Distinct();
 
-				IEnumerable<object> subscribedInstances =
-				    instanceSubscriptions
-					.Select(x => x.Subscriber)
-					.Distinct();
-					
-				IEnumerable<Type> subscribedActionTypes =
-					instanceSubscriptions
-						.Select(x => x.ActionType)
-						.Distinct();
+                IEnumerable<Type> subscribedActionTypes =
+                    instanceSubscriptions
+                        .Select(x => x.ActionType)
+                        .Distinct();
 
-				foreach(Type actionType in subscribedActionTypes)
-				{
-					List<ActionSubscription> actionTypeSubscriptions;
-					if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
-						continue;
-					SubscriptionsForType[actionType] = actionTypeSubscriptions
-						.Except(instanceSubscriptions)
-						.ToList();
-				}
-				
-				foreach (object subscription in subscribedInstances)
-				{
-				    if (SubscriptionsForInstance.ContainsKey(subscription))
-					SubscriptionsForInstance.Remove(subscription);
-				}
-			}
-		}
-	}
+                foreach (Type actionType in subscribedActionTypes)
+                {
+                    List<ActionSubscription> actionTypeSubscriptions;
+                    if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
+                        continue;
+                    SubscriptionsForType[actionType] = actionTypeSubscriptions
+                        .Except(instanceSubscriptions)
+                        .ToList();
+                }
+
+                foreach (object subscription in subscribedInstances)
+                {
+                    SubscriptionsForInstance.Remove(subscription);
+                }
+            }
+        }
+    }
 }

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -4,101 +4,102 @@ using System.Linq;
 
 namespace Fluxor
 {
-    internal class ActionSubscriber : IActionSubscriber
-    {
-        private readonly object SyncRoot = new();
-        private readonly Dictionary<object, List<ActionSubscription>> SubscriptionsForInstance = new();
-        private readonly Dictionary<Type, List<ActionSubscription>> SubscriptionsForType = new();
+	internal class ActionSubscriber : IActionSubscriber
+	{
+		private readonly object SyncRoot = new();
+		private readonly Dictionary<object, List<ActionSubscription>> SubscriptionsForInstance = new();
+		private readonly Dictionary<Type, List<ActionSubscription>> SubscriptionsForType = new();
 
-        public IDisposable GetActionUnsubscriberAsIDisposable(object subscriber) =>
-            new DisposableCallback(
-                id: $"{nameof(ActionSubscriber)}.{nameof(GetActionUnsubscriberAsIDisposable)}",
-                action: () => UnsubscribeFromAllActions(subscriber));
 
-        public void Notify(object action)
-        {
-            if (action is null)
-                throw new ArgumentNullException(nameof(action));
+		public IDisposable GetActionUnsubscriberAsIDisposable(object subscriber) =>
+			new DisposableCallback(
+				id: $"{nameof(ActionSubscriber)}.{nameof(GetActionUnsubscriberAsIDisposable)}",
+				action: () => UnsubscribeFromAllActions(subscriber));
 
-            lock (SyncRoot)
-            {
-                IEnumerable<Action<object>> callbacks =
-                    SubscriptionsForType
-                        .Where(x => x.Key.IsAssignableFrom(action.GetType()))
-                        .SelectMany(x => x.Value)
-                        .Select(x => x.Callback)
-                        .ToArray();
-                foreach (Action<object> callback in callbacks)
-                    callback(action);
-            }
-        }
+		public void Notify(object action)
+		{
+			if (action is null)
+				throw new ArgumentNullException(nameof(action));
 
-        public void SubscribeToAction<TAction>(object subscriber, Action<TAction> callback)
-        {
-            if (subscriber is null)
-                throw new ArgumentNullException(nameof(subscriber));
-            if (callback is null)
-                throw new ArgumentNullException(nameof(callback));
+			lock (SyncRoot)
+			{
+				IEnumerable<Action<object>> callbacks =
+					SubscriptionsForType
+						.Where(x => x.Key.IsAssignableFrom(action.GetType()))
+						.SelectMany(x => x.Value)
+						.Select(x => x.Callback)
+						.ToArray();
+				foreach (Action<object> callback in callbacks)
+					callback(action);
+			}
+		}
 
-            var subscription = new ActionSubscription(
-                subscriber: subscriber,
-                actionType: typeof(TAction),
-                callback: (object action) => callback((TAction)action));
+		public void SubscribeToAction<TAction>(object subscriber, Action<TAction> callback)
+		{
+			if (subscriber is null)
+				throw new ArgumentNullException(nameof(subscriber));
+			if (callback is null)
+				throw new ArgumentNullException(nameof(callback));
 
-            lock (SyncRoot)
-            {
-                if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
-                {
-                    instanceSubscriptions = new List<ActionSubscription>();
-                    SubscriptionsForInstance[subscriber] = instanceSubscriptions;
-                }
-                instanceSubscriptions.Add(subscription);
+			var subscription = new ActionSubscription(
+				subscriber: subscriber,
+				actionType: typeof(TAction),
+				callback: (object action) => callback((TAction)action));
 
-                if (!SubscriptionsForType.TryGetValue(typeof(TAction), out List<ActionSubscription> typeSubscriptions))
-                {
-                    typeSubscriptions = new List<ActionSubscription>();
-                    SubscriptionsForType[typeof(TAction)] = typeSubscriptions;
-                }
-                typeSubscriptions.Add(subscription);
-            };
-        }
+			lock (SyncRoot)
+			{
+				if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
+				{
+					instanceSubscriptions = new List<ActionSubscription>();
+					SubscriptionsForInstance[subscriber] = instanceSubscriptions;
+				}
+				instanceSubscriptions.Add(subscription);
 
-        public void UnsubscribeFromAllActions(object subscriber)
-        {
-            if (subscriber is null)
-                throw new ArgumentNullException(nameof(subscriber));
+				if (!SubscriptionsForType.TryGetValue(typeof(TAction), out List<ActionSubscription> typeSubscriptions))
+				{
+					typeSubscriptions = new List<ActionSubscription>();
+					SubscriptionsForType[typeof(TAction)] = typeSubscriptions;
+				}
+				typeSubscriptions.Add(subscription);
+			};
+		}
 
-            List<ActionSubscription> instanceSubscriptions;
-            lock (SyncRoot)
-            {
-                if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
-                    return;
+		public void UnsubscribeFromAllActions(object subscriber)
+		{
+			if (subscriber is null)
+				throw new ArgumentNullException(nameof(subscriber));
 
-                IEnumerable<object> subscribedInstances =
-                    instanceSubscriptions
-                    .Select(x => x.Subscriber)
-                    .Distinct();
+			List<ActionSubscription> instanceSubscriptions;
+			lock (SyncRoot)
+			{
+				if (!SubscriptionsForInstance.TryGetValue(subscriber, out instanceSubscriptions))
+					return;
 
-                IEnumerable<Type> subscribedActionTypes =
-                    instanceSubscriptions
-                        .Select(x => x.ActionType)
-                        .Distinct();
+				IEnumerable<object> subscribedInstances =
+					instanceSubscriptions
+					.Select(x => x.Subscriber)
+					.Distinct();
 
-                foreach (Type actionType in subscribedActionTypes)
-                {
-                    List<ActionSubscription> actionTypeSubscriptions;
-                    if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
-                        continue;
-                    SubscriptionsForType[actionType] = actionTypeSubscriptions
-                        .Except(instanceSubscriptions)
-                        .ToList();
-                }
+				IEnumerable<Type> subscribedActionTypes =
+					instanceSubscriptions
+						.Select(x => x.ActionType)
+						.Distinct();
 
-                foreach (object subscription in subscribedInstances)
-                {
-                    SubscriptionsForInstance.Remove(subscription);
-                }
-            }
-        }
-    }
+				foreach (Type actionType in subscribedActionTypes)
+				{
+					List<ActionSubscription> actionTypeSubscriptions;
+					if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
+						continue;
+					SubscriptionsForType[actionType] = actionTypeSubscriptions
+						.Except(instanceSubscriptions)
+						.ToList();
+				}
+
+				foreach (object subscription in subscribedInstances)
+				{
+					SubscriptionsForInstance.Remove(subscription);
+				}
+			}
+		}
+	}
 }

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -21,7 +21,7 @@ namespace Fluxor
 			if (action is null)
 				throw new ArgumentNullException(nameof(action));
 
-			lock (SyncRoot)
+			lock(SyncRoot)
 			{
 				IEnumerable<Action<object>> callbacks =
 					SubscriptionsForType
@@ -46,7 +46,7 @@ namespace Fluxor
 				actionType: typeof(TAction),
 				callback: (object action) => callback((TAction)action));
 
-			lock (SyncRoot)
+			lock(SyncRoot)
 			{
 				if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
 				{
@@ -85,7 +85,7 @@ namespace Fluxor
 						.Select(x => x.ActionType)
 						.Distinct();
 
-				foreach (Type actionType in subscribedActionTypes)
+				foreach(Type actionType in subscribedActionTypes)
 				{
 					List<ActionSubscription> actionTypeSubscriptions;
 					if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
@@ -95,7 +95,7 @@ namespace Fluxor
 						.ToList();
 				}
 
-				foreach (object subscription in subscribedInstances)
+				foreach(object subscription in subscribedInstances)
 				{
 					SubscriptionsForInstance.Remove(subscription);
 				}

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -77,8 +77,8 @@ namespace Fluxor
 
 				IEnumerable<object> subscribedInstances =
 					instanceSubscriptions
-					.Select(x => x.Subscriber)
-					.Distinct();
+						.Select(x => x.Subscriber)
+						.Distinct();
 
 				IEnumerable<Type> subscribedActionTypes =
 					instanceSubscriptions

--- a/Source/Lib/Fluxor/ActionSubscriber.cs
+++ b/Source/Lib/Fluxor/ActionSubscriber.cs
@@ -21,7 +21,7 @@ namespace Fluxor
 			if (action is null)
 				throw new ArgumentNullException(nameof(action));
 
-			lock(SyncRoot)
+			lock (SyncRoot)
 			{
 				IEnumerable<Action<object>> callbacks =
 					SubscriptionsForType
@@ -46,7 +46,7 @@ namespace Fluxor
 				actionType: typeof(TAction),
 				callback: (object action) => callback((TAction)action));
 
-			lock(SyncRoot)
+			lock (SyncRoot)
 			{
 				if (!SubscriptionsForInstance.TryGetValue(subscriber, out List<ActionSubscription> instanceSubscriptions))
 				{
@@ -85,7 +85,7 @@ namespace Fluxor
 						.Select(x => x.ActionType)
 						.Distinct();
 
-				foreach(Type actionType in subscribedActionTypes)
+				foreach (Type actionType in subscribedActionTypes)
 				{
 					List<ActionSubscription> actionTypeSubscriptions;
 					if (!SubscriptionsForType.TryGetValue(actionType, out actionTypeSubscriptions))
@@ -95,7 +95,7 @@ namespace Fluxor
 						.ToList();
 				}
 
-				foreach(object subscription in subscribedInstances)
+				foreach (object subscription in subscribedInstances)
 					SubscriptionsForInstance.Remove(subscription);
 			}
 		}


### PR DESCRIPTION
Fixes memory leak when using `ActionSubscriber` or `SubscribeToAction`