### PR TITLE
Argument order fix

### DIFF
--- a/Source/Tutorials/01-BasicConcepts/01B-EffectsTutorial/README.md
+++ b/Source/Tutorials/01-BasicConcepts/01B-EffectsTutorial/README.md
@@ -310,7 +310,7 @@ action into state.
 
 ```c#
 [ReducerMethod]
-public static WeatherState ReduceFetchDataResultAction(FetchDataResultAction action, WeatherState state) =>
+public static WeatherState ReduceFetchDataResultAction(WeatherState state, FetchDataResultAction action) =>
   new WeatherState(
     isLoading: false,
     forecasts: action.Forecasts);


### PR DESCRIPTION
Fixed order of arguments in `ReduceFetchDataResultAction()`

This was a bit of a noodle scratcher, the error message didn't shed much light on what was wrong.

> Expected reducer method to return type FluxorCli.Store.WeatherUseCase.WeatherState. Method "ReduceFetchDataResultAction" on class "FluxorCli.Store.WeatherUseCase.Reducers.Reducers"