### PR TITLE
Fix deadlock during store initialize when another thread dispatches an action

### DIFF
--- a/Source/Lib/Fluxor/Store.cs
+++ b/Source/Lib/Fluxor/Store.cs
@@ -276,7 +276,6 @@ namespace Fluxor
 			if (IsDispatching)
 				return;
 
-			var dispatchedActions = new List<object>();
 			IsDispatching = true;
 			try
 			{
@@ -293,7 +292,7 @@ namespace Fluxor
 
 						ActionSubscriber?.Notify(nextActionToProcess);
 						ExecuteMiddlewareAfterDispatch(nextActionToProcess);
-						dispatchedActions.Add(nextActionToProcess);
+						TriggerEffects(nextActionToProcess);
 					}
 				}
 			}
@@ -301,8 +300,6 @@ namespace Fluxor
 			{
 				IsDispatching = false;
 			}
-			foreach (var dispatchedAction in dispatchedActions)
-				TriggerEffects(dispatchedAction);
 		}
 	}
 }

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/DispatchWhileInitializingTests.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/DispatchWhileInitializingTests.cs
@@ -13,7 +13,7 @@ namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTe
 		private readonly IFeature<CounterState> Feature;
 
 		[Fact]
-		public async Task WhenObserverSubscribesToAnAction_AndDispatchesAnActionFromANewThread_ThenThereShouldBeNoDeadlock()
+		public async Task WhenInitializeTakesAWhile_AndTriggersEffectThatDispatchesAnAction_AndAnotherThreadDispatchesAnAction_ThenThereShouldBeNoDeadlock()
 		{
 			Thread initialThread = Thread.CurrentThread; 
 

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/DispatchWhileInitializingTests.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/DispatchWhileInitializingTests.cs
@@ -1,0 +1,42 @@
+﻿using Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests
+{
+	public class DispatchWhileInitializingTests
+	{
+		private readonly IDispatcher Dispatcher;
+		private readonly IStore Subject;
+		private readonly IFeature<CounterState> Feature;
+
+		[Fact]
+		public async Task WhenObserverSubscribesToAnAction_AndDispatchesAnActionFromANewThread_ThenThereShouldBeNoDeadlock()
+		{
+			Thread initialThread = Thread.CurrentThread; 
+
+			var timeout = Task.Delay(1000);
+			var initialize = Task.Run(async () => await Subject.InitializeAsync());
+			var dispatch = Task.Run(async () =>
+			{
+				await Task.Delay(50);
+				Dispatcher.Dispatch(new IncrementCounterAction());
+			});
+
+			await Task.WhenAny(timeout, Task.WhenAll(initialize, dispatch));
+			Assert.False(timeout.IsCompleted, "Time out due to deadlock");
+		}
+
+		public DispatchWhileInitializingTests()
+		{
+			Dispatcher = new Dispatcher();
+			Subject = new Store(Dispatcher);
+
+			Feature = new CounterFeature();
+			Subject.AddFeature(Feature);
+			Subject.AddEffect(new EffectThatEmitsActions(new[] { new TestAction() }));
+		}
+	}
+}

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/CounterFeature.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/CounterFeature.cs
@@ -1,0 +1,8 @@
+﻿namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	class CounterFeature : Feature<CounterState>
+	{
+		public override string GetName() => "Counter";
+		protected override CounterState GetInitialState() => new(counter: 0);
+	}
+}

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/CounterState.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/CounterState.cs
@@ -1,0 +1,13 @@
+﻿namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	public class CounterState
+	{
+		public readonly int Counter;
+
+		public CounterState(int counter)
+		{
+			Counter = counter;
+		}
+	}
+}
+

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/EffectThatEmitsActions.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/EffectThatEmitsActions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	public class EffectThatEmitsActions : Effect<StoreInitializedAction>
+	{
+		public readonly object[] ActionsToEmit;
+
+		public EffectThatEmitsActions(object[] actionsToEmit)
+		{
+			ActionsToEmit = actionsToEmit ?? Array.Empty<object>();
+		}
+		public override Task HandleAsync(StoreInitializedAction action, IDispatcher dispatcher)
+		{
+			Thread.Sleep(500);
+			foreach (object actionToEmit in ActionsToEmit)
+				dispatcher.Dispatch(actionToEmit);
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/IncrementCounterAction.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/IncrementCounterAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	class IncrementCounterAction
+	{
+	}
+}

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/IsolatedTests.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/IsolatedTests.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	public class IsolatedTests : Middleware
+	{
+	}
+}

--- a/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/TestAction.cs
+++ b/Source/Tests/Fluxor.UnitTests/StoreTests/ThreadingTests/DispatchWhileInitializingTests/SupportFiles/TestAction.cs
@@ -1,0 +1,6 @@
+﻿namespace Fluxor.UnitTests.StoreTests.ThreadingTests.DispatchWhileInitializingTests.SupportFiles
+{
+	public class TestAction
+	{
+	}
+}


### PR DESCRIPTION
There is a deadlock issue (race condition) when the store is initialized and another thread dispatches an action at just the time when the store initialization is about to trigger effects and there is an effect that dispatches an action immediately.