### PR TITLE
Fix: deadlock caused by event invocation within lock

### DIFF
--- a/Source/Lib/Fluxor/Dispatcher.cs
+++ b/Source/Lib/Fluxor/Dispatcher.cs
@@ -41,16 +41,19 @@ namespace Fluxor
 			if (action is null)
 				throw new ArgumentNullException(nameof(action));
 
+			bool actionDispatchedIsNull;
 			lock (SyncRoot)
 			{
-				if (_ActionDispatched is not null)
-					_ActionDispatched(this, new ActionDispatchedEventArgs(action));
-				else
+				actionDispatchedIsNull = _ActionDispatched is null;
+                if (actionDispatchedIsNull)
 					QueuedActions.Enqueue(action);
 			}
-		}
 
-		private void DequeueActions()
+			if (!actionDispatchedIsNull)
+				_ActionDispatched(this, new ActionDispatchedEventArgs(action));
+        }
+
+        private void DequeueActions()
 		{
 			foreach (object queuedAction in QueuedActions)
 				_ActionDispatched(this, new ActionDispatchedEventArgs(queuedAction));

--- a/Source/Lib/Fluxor/Feature.cs
+++ b/Source/Lib/Fluxor/Feature.cs
@@ -91,16 +91,20 @@ namespace Fluxor
 			}
 			protected set
 			{
+				bool stateHasChanged;
+
 				lock (SyncRoot)
 				{
-					bool stateHasChanged = !Object.ReferenceEquals(_State, value);
+					stateHasChanged = !Object.ReferenceEquals(_State, value);
 					if (stateHasChanged)
 					{
 						_State = value;
 						HasInitialState = true;
-						TriggerStateChangedCallbacksThrottler.Invoke(MaximumStateChangedNotificationsPerSecond);
 					}
 				}
+
+				if (stateHasChanged)
+					TriggerStateChangedCallbacksThrottler.Invoke(MaximumStateChangedNotificationsPerSecond);
 			}
 		}
 


### PR DESCRIPTION
I am running Blazor natively with [photino.Blazor (github)](https://github.com/tryphotino/photino.Blazor).

I experience a deadlock in [Feature.cs](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs) due to a lock which goes on to cause another lock on the same object.

Presumably the intention is that the same thread is doing this double lock, but I encounter two separate threads trying to enter the lock.

It starts with me dispatching an Action, in my case I'm clicking the button in the following image.

<img width="391" alt="100_nothing" src="https://github.com/mrpmorris/Fluxor/assets/45454132/d19d2438-a6d0-4038-9380-672026d4ead3">

That button click results in this function being ran [Feature.ReceiveDispatchNotificationFromStore](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L115)

<img width="955" alt="200_ReceiveDispatchNotificationFromStore" src="https://github.com/mrpmorris/Fluxor/assets/45454132/d2f899ae-e465-4d56-b36c-4109446554fa">

This function, at the end, [invokes the setter for the property named "State"](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L127).

<img width="592" alt="300_State" src="https://github.com/mrpmorris/Fluxor/assets/45454132/07bd6508-a9f2-497a-94ea-240837dfd26d">

<img width="887" alt="400_Setter" src="https://github.com/mrpmorris/Fluxor/assets/45454132/b63eb5e8-86fd-4122-ac56-cb90dec7b840">

[The setter for "State" is here](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L92).
When I enter the lock, my thread according to the Visual Studio debugger is identified by "40512 .NET Thread" 

<img width="349" alt="500_state_setter_thread" src="https://github.com/mrpmorris/Fluxor/assets/45454132/e060067b-d94b-406b-b238-7209a6180a23">

After the 'State' has its state changed, [an event is invoked via the 'TriggerStateChangedCallbacksThrottler'](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L101).

<img width="998" alt="600_state_setter_event" src="https://github.com/mrpmorris/Fluxor/assets/45454132/dd40956e-525a-4572-8565-ba39807fee63">

The code then goes to the [StateChanged event's 'add'](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L52)

<img width="552" alt="700_second_lock" src="https://github.com/mrpmorris/Fluxor/assets/45454132/5d46e8a9-ad40-4caf-8ac3-7827829fb82e">

A [lock on 'SyncRoot'](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L56) is performed again. However, if I check my thread, the Visual Studio debuggers says I'm on the thread identified by "40600 Main Thread". This is different from the previous time the lock was entered, of which has not yet been left.

<img width="330" alt="700_second_lock_thread" src="https://github.com/mrpmorris/Fluxor/assets/45454132/b558f8d2-ceef-42ff-b3ad-3dcfa3f260de">

Therefore, I encounter a deadlock and the app freezes.

[Within the setter for State](https://github.com/mrpmorris/Fluxor/blob/master/Source/Lib/Fluxor/Feature.cs#L96), If I declare the "bool stateHasChanged" outside of the lock.

I can allow the lock to close, prior to invoking the event. This "seems" to have fixed my issue. I might have been doing something wrong from the get-go to even end up in this scenario however, I'm unsure.

I do not believe this can cause any issues, because I believe this event only notifies Blazor components to re-render?

<img width="916" alt="800_the_change" src="https://github.com/mrpmorris/Fluxor/assets/45454132/379640e7-da6e-41ab-bb9d-9dc48376ab50">

<img width="372" alt="900_try_change" src="https://github.com/mrpmorris/Fluxor/assets/45454132/5eb380c9-c589-42aa-9628-ddcda6d14c1f">

<img width="562" alt="1000_result" src="https://github.com/mrpmorris/Fluxor/assets/45454132/a5f3e57d-f73f-4128-9423-54e646dfb1ec">

Additional information:
The code I am encountering this issue with is public and can be found here if that is of use:
[Luthetus/Luthetus.Ide (github)](https://github.com/Luthetus/Luthetus.Ide)

Furthermore, the source code for the Blazor component in the images is at this link (line number for the method invoked is included in the link):
https://github.com/Luthetus/Luthetus.Ide/blob/main/Luthetus.Ide/Source/Lib/Luthetus.Ide.RazorLib/DotNetSolutions/Displays/DotNetSolutionFormDisplay.razor.cs#L60
