### PR TITLE
Possible fix for .NET 8 Blazor Web App breakage

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -15,6 +15,9 @@ namespace Fluxor.Blazor.Web.Components
 		[Inject]
 		private IActionSubscriber ActionSubscriber { get; set; }
 
+		[Inject]
+		private IStore Store { get; set; }
+
 		private bool Disposed;
 		private IDisposable StateSubscription;
 		private readonly ThrottledInvoker StateHasChangedThrottler;
@@ -22,7 +25,7 @@ namespace Fluxor.Blazor.Web.Components
 		/// <summary>
 		/// Creates a new instance
 		/// </summary>
-		public FluxorComponent()
+		protected FluxorComponent()
 		{
 			StateHasChangedThrottler = new ThrottledInvoker(() =>
 			{
@@ -65,28 +68,25 @@ namespace Fluxor.Blazor.Web.Components
 				Disposed = true;
 			}
 		}
-
-		protected override async Task OnAfterRenderAsync(bool firstRender)
-		{
-			if (firstRender)
-			{
-				//Attempt to initialize the store knowing that if it's already been initialized, this won't do anything.
-				await Store.InitializeAsync();
-			}
-
-			await base.OnAfterRenderAsync(firstRender);
-		}
-
+		
 		/// <summary>
 		/// Subscribes to state properties
 		/// </summary>
 		protected override void OnInitialized()
 		{
-			base.OnInitialized();
 			StateSubscription = StateSubscriber.Subscribe(this, _ =>
 			{
 				StateHasChangedThrottler.Invoke(MaximumStateChangedNotificationsPerSecond);
 			});
+
+			base.OnInitialized();
+		}
+
+		protected override async Task OnInitializedAsync()
+		{
+			//Attempt to initialize the store knowing that if it's already been initialized, this won't do anything.
+			await Store.InitializeAsync();
+			await base.OnInitializedAsync();
 		}
 
 		protected virtual void Dispose(bool disposing)

--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -65,6 +65,17 @@ namespace Fluxor.Blazor.Web.Components
 		}
 
 		/// <summary>
+		/// Initializes the store (primarily intended for WASM components and pages).
+		/// </summary>
+		protected override void async Task OnParametersSetAsync()
+		{
+			await base.OnParametersSetAsync();
+
+			//Attempt to initialize the store knowing that if it's already been initialized, this won't do anything
+			await Store.InitializeAsync();
+		}
+
+		/// <summary>
 		/// Subscribes to state properties
 		/// </summary>
 		protected override void OnInitialized()

--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Components;
 using System.Threading;
 using System;
+using System.Threading.Tasks;
 
 namespace Fluxor.Blazor.Web.Components
 {
@@ -65,15 +66,15 @@ namespace Fluxor.Blazor.Web.Components
 			}
 		}
 
-		/// <summary>
-		/// Initializes the store (primarily intended for WASM components and pages).
-		/// </summary>
-		protected override void async Task OnParametersSetAsync()
+		protected override async Task OnAfterRenderAsync(bool firstRender)
 		{
-			await base.OnParametersSetAsync();
+			if (firstRender)
+			{
+				//Attempt to initialize the store knowing that if it's already been initialized, this won't do anything.
+				await Store.InitializeAsync();
+			}
 
-			//Attempt to initialize the store knowing that if it's already been initialized, this won't do anything
-			await Store.InitializeAsync();
+			await base.OnAfterRenderAsync(firstRender);
 		}
 
 		/// <summary>

--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Fluxor.UnsupportedClasses;
 using Microsoft.AspNetCore.Components;
+using System.Threading;
 using System;
 
 namespace Fluxor.Blazor.Web.Components

--- a/Source/Lib/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
+++ b/Source/Lib/Fluxor.Blazor.Web/Fluxor.Blazor.Web.csproj
@@ -12,9 +12,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
 	</ItemGroup>

--- a/Source/Lib/Fluxor.Blazor.Web/Persistence/PersistenceEffects.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Persistence/PersistenceEffects.cs
@@ -1,0 +1,59 @@
+﻿using Fluxor.Persistence;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fluxor.Blazor.Web.Persistence
+{
+#if NET6_0_OR_GREATER
+	public sealed class PersistenceEffects
+	{
+		private readonly IPersistenceManager _persistenceManager;
+		private readonly IServiceProvider _serviceProvider;
+
+		public PersistenceEffects(IPersistenceManager persistenceManager, IServiceProvider serviceProvider)
+		{
+			_persistenceManager = persistenceManager;
+			_serviceProvider = serviceProvider;
+		}
+
+		/// <summary>
+		/// Maintains a reference to IStore - injected this way to avoid a circular dependency during the effect method registration
+		/// </summary>
+		private readonly Lazy<IStore> _store = new(_serviceProvider.GetRequiredService<IStore>);
+
+		[EffectMethod(typeof(StorePersistingAction))]
+		public async Task PersistStoreData(IDispatcher dispatcher)
+		{
+			//Serialize the store
+			var json = _store.Value.SerializeToJson();
+
+			//Save to the persistence manager
+			await _persistenceManager.PersistStoreToStateAsync(json);
+
+			//Completed
+			dispatcher.Dispatch(new StorePersistedAction());
+		}
+
+		[EffectMethod(typeof(StoreRehydratingAction))]
+		public async Task RehydrateStoreData(IDispatcher dispatcher)
+		{
+			//Read from the persistence manager
+			var serializedStore = await _persistenceManager.RehydrateStoreFromStateAsync();
+			if (serializedStore is null)
+			{
+				//Nothing to rehydrate - leave as-is
+				dispatcher.Dispatch(new StoreRehydratedAction());
+				return;
+			}
+
+			_store.Value.RehydrateFromJson(serializedStore);
+
+			//Completed
+			dispatcher.Dispatch(new StoreRehydratedAction());
+		}
+	}
+#endif
+}

--- a/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
@@ -53,6 +53,7 @@ namespace Fluxor.Blazor.Web
 		protected override async Task OnInitializedAsync()
 		{
 			await Store.InitializeAsync();
+			await base.OnInitializedAsync();
 		}
 #endif
 

--- a/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
@@ -48,6 +48,10 @@ namespace Fluxor.Blazor.Web
 			MiddlewareInitializationScripts = scriptBuilder.ToString();
 			base.OnInitialized();
 		}
+		protected override async Task OnInitializedAsync()
+		{
+			await Store.InitializeAsync();
+		}
 
 		protected override void OnAfterRender(bool firstRender)
 		{
@@ -72,8 +76,6 @@ namespace Fluxor.Blazor.Web
 				{
 					if (!string.IsNullOrWhiteSpace(MiddlewareInitializationScripts))
 						await JSRuntime.InvokeVoidAsync("eval", MiddlewareInitializationScripts);
-
-					await Store.InitializeAsync();
 				}
 				catch (JSException err)
 				{

--- a/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
@@ -48,10 +48,13 @@ namespace Fluxor.Blazor.Web
 			MiddlewareInitializationScripts = scriptBuilder.ToString();
 			base.OnInitialized();
 		}
+
+#if NET8
 		protected override async Task OnInitializedAsync()
 		{
 			await Store.InitializeAsync();
 		}
+#endif
 
 		protected override void OnAfterRender(bool firstRender)
 		{
@@ -76,6 +79,10 @@ namespace Fluxor.Blazor.Web
 				{
 					if (!string.IsNullOrWhiteSpace(MiddlewareInitializationScripts))
 						await JSRuntime.InvokeVoidAsync("eval", MiddlewareInitializationScripts);
+
+#if !NET8
+					await Store.InitializeAsync();
+#endif
 				}
 				catch (JSException err)
 				{

--- a/Source/Lib/Fluxor/DependencyInjection/FluxorOptions.cs
+++ b/Source/Lib/Fluxor/DependencyInjection/FluxorOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Fluxor.Extensions;
+using Fluxor.Persistence;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -138,5 +139,32 @@ namespace Fluxor.DependencyInjection
 			.ToArray();
 			return this;
 		}
+
+#if NET6_0_OR_GREATER
+
+		/// <summary>
+		/// Enables automatic store persistence between location state changes.
+		/// </summary>
+		/// <typeparam name="T">The type of persistence implementation to use.</typeparam>
+		/// <returns>Options</returns>
+		public FluxorOptions WithPersistence<T>() where T : IPersistenceManager
+		{
+			Services.AddScoped(typeof(IPersistenceManager), typeof(T));
+			return this;
+		}
+
+		/// <summary>
+		/// Enables automatic store persistence between location state changes.
+		/// </summary>
+		/// <typeparam name="T">The type of persistence implementation to use.</typeparam>
+		/// <returns>Options</returns>
+		public FluxorOptions WithPersistence<T>(IServiceCollection serviceCollection) where T : IPersistenceManager
+		{
+			WithPersistence<T>();
+			foreach (var serviceDescriptor in serviceCollection) Services.Add(serviceDescriptor);
+			return this;
+		}
+
+#endif
 	}
 }

--- a/Source/Lib/Fluxor/DependencyInjection/ServiceRegistration/StoreRegistration.cs
+++ b/Source/Lib/Fluxor/DependencyInjection/ServiceRegistration/StoreRegistration.cs
@@ -1,5 +1,6 @@
 ﻿using Fluxor.DependencyInjection.WrapperFactories;
 using Fluxor.Extensions;
+using Fluxor.Persistence;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -41,7 +42,13 @@ namespace Fluxor.DependencyInjection.ServiceRegistration
 			services.Add(typeof(Store), serviceProvider =>
 			{
 				var dispatcher = serviceProvider.GetService<IDispatcher>();
+
+#if NET6_0_OR_GREATER
+				var persistenceManager = serviceProvider.GetService<IPersistenceManager>();
+				var store = new Store(dispatcher, persistenceManager);
+#else
 				var store = new Store(dispatcher);
+#endif
 				foreach (FeatureClassInfo featureClassInfo in featureClassInfos)
 				{
 					var feature = (IFeature)serviceProvider.GetService(featureClassInfo.FeatureInterfaceGenericType);

--- a/Source/Lib/Fluxor/Fluxor.csproj
+++ b/Source/Lib/Fluxor/Fluxor.csproj
@@ -4,7 +4,7 @@
 		<Description>A zero boilerplate Redux/Flux framework for .NET</Description>
 		<PackageIcon>fluxor-small-logo.png</PackageIcon>
 		<PackageTags>Redux Flux DotNet CSharp</PackageTags>
-		<SignAssembly Condition="'$(Configuration)'=='Release'" >True</SignAssembly>
+		<SignAssembly Condition="'$(Configuration)'=='Release'">True</SignAssembly>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -20,5 +20,6 @@
 		<PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 		<PackageReference Condition="'$(TargetFramework)' == 'net5.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
 		<PackageReference Condition="'$(TargetFramework)' != 'net7.0' AND '$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net5.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
+		<PackageReference Include="System.Text.Json" Version="4.7.2" />
 	</ItemGroup>
 </Project>

--- a/Source/Lib/Fluxor/Fluxor.csproj
+++ b/Source/Lib/Fluxor/Fluxor.csproj
@@ -15,6 +15,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Condition="'$(TargetFramework)' == 'net8.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
 		<PackageReference Condition="'$(TargetFramework)' == 'net7.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
 		<PackageReference Condition="'$(TargetFramework)' == 'net6.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 		<PackageReference Condition="'$(TargetFramework)' == 'net5.0'" Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/Source/Lib/Fluxor/IStore.cs
+++ b/Source/Lib/Fluxor/IStore.cs
@@ -93,5 +93,18 @@ namespace Fluxor
 		/// Executed when an exception is not handled
 		/// </summary>
 		event EventHandler<Exceptions.UnhandledExceptionEventArgs> UnhandledException;
+
+		/// <summary>
+		/// Persists the features in the store to a serialized string.
+		/// </summary>
+		/// <returns></returns>
+		string SerializeToJson();
+
+		/// <summary>
+		/// Deserializes a previously serialized store and rehydrates each feature using the
+		/// provided values.
+		/// </summary>
+		/// <param name="json">The serialized store.</param>
+		void RehydrateFromJson(string json);
 	}
 }

--- a/Source/Lib/Fluxor/Persistence/IPersistenceManager.cs
+++ b/Source/Lib/Fluxor/Persistence/IPersistenceManager.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fluxor.Persistence
+{
+	public interface IPersistenceManager
+	{
+		/// <summary>
+		/// Persists the store to a persisted state.
+		/// </summary>
+		/// <param name="serializedStore">The serialized store data being persisted.</param>
+		public Task PersistStoreToStateAsync(string serializedStore);
+
+		/// <summary>
+		/// Rehydrates the store from a persisted state.
+		/// </summary>
+		public Task<string?> RehydrateStoreFromStateAsync();
+
+		/// <summary>
+		/// Clears the store from the persisted state.
+		/// </summary>
+		public Task ClearStoreFromStateAsync();
+	}
+}

--- a/Source/Lib/Fluxor/Persistence/PersistenceEffects.cs
+++ b/Source/Lib/Fluxor/Persistence/PersistenceEffects.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fluxor.Persistence
+{
+	public sealed class PersistenceEffects
+	{
+		private readonly IPersistenceManager _persistenceManager;
+		private readonly IServiceProvider _serviceProvider;
+
+		public PersistenceEffects(IPersistenceManager persistenceManager, IServiceProvider serviceProvider)
+		{
+			_persistenceManager = persistenceManager;
+			_serviceProvider = serviceProvider;
+		}
+
+		/// <summary>
+		/// Maintains a reference to IStore - injected this way to avoid a circular dependency during the effect method registration
+		/// </summary>
+		private readonly Lazy<IStore> _store = new(_serviceProvider.GetRequiredService<IStore>);
+
+		[EffectMethod(typeof(StorePersistingAction))]
+		public async Task PersistStoreData(IDispatcher dispatcher)
+		{
+			//Serialize the store
+			var json = _store.Value.SerializeToJson();
+
+			//Save to the persistence manager
+			await _persistenceManager.PersistStoreToStateAsync(json);
+
+			//Completed
+			dispatcher.Dispatch(new StorePersistedAction());
+		}
+
+		[EffectMethod(typeof(StoreRehydratingAction))]
+		public async Task RehydrateStoreData(IDispatcher dispatcher)
+		{
+			//Read from the persistence manager
+			var serializedStore = await _persistenceManager.RehydrateStoreFromStateAsync();
+			if (serializedStore is null)
+			{
+				//Nothing to rehydrate - leave as-is
+				dispatcher.Dispatch(new StoreRehydratedAction());
+				return;
+			}
+
+			_store.Value.RehydrateFromJson(serializedStore);
+
+			//Completed
+			dispatcher.Dispatch(new StoreRehydratedAction());
+		}
+	}
+}

--- a/Source/Lib/Fluxor/Persistence/StorePersistedAction.cs
+++ b/Source/Lib/Fluxor/Persistence/StorePersistedAction.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluxor.Persistence
+{
+	/// <summary>
+	/// Dispatched by the store once it has been successfully persisted to state.
+	/// </summary>
+	public sealed class StorePersistedAction
+	{
+	}
+}

--- a/Source/Lib/Fluxor/Persistence/StorePersistingAction.cs
+++ b/Source/Lib/Fluxor/Persistence/StorePersistingAction.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluxor.Persistence
+{
+	/// <summary>
+	/// Dispatched by the store once it has started persisting to state.
+	/// </summary>
+	public sealed class StorePersistingAction
+	{
+	}
+}

--- a/Source/Lib/Fluxor/Persistence/StoreRehydratedAction.cs
+++ b/Source/Lib/Fluxor/Persistence/StoreRehydratedAction.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluxor.Persistence
+{
+	/// <summary>
+	/// Dispatched by the store once it has been successfully rehydrated from state.
+	/// </summary>
+	public sealed class StoreRehydratedAction
+	{
+	}
+}

--- a/Source/Lib/Fluxor/Persistence/StoreRehydratingAction.cs
+++ b/Source/Lib/Fluxor/Persistence/StoreRehydratingAction.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fluxor.Persistence
+{
+	/// <summary>
+	/// Dispatched by the store once it has started rehydrating from state.
+	/// </summary>
+	public sealed class StoreRehydratingAction
+	{
+	}
+}


### PR DESCRIPTION
Adds .NET 8 as a valid target in addition to .NET 7 and the other versions.

Also moves state initialization out from `OnAfterRenderAsync` (which doesn't run on server anymore [per the docs](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?view=aspnetcore-8.0#after-component-render-onafterrenderasync)) to `OnInitializedAsync` which runs after existing logic in `OnInitialized` and after `OnParametersSet` (which in .NET 8 now runs before `OnInitialized{Async}`), so it's the last lifecycle method before `OnAfterRender`, assuming it were still being called.

I'm having problems getting Fluxor.Blazor.Web to build on my machine (likely missing one of your targets) so I haven't yet tested this, but as covered in the [related issue,](https://github.com/mrpmorris/Fluxor/issues/480), when I set a breakpoint in the ActionDispatched method, I can see that the actions are accumulating in the Store and they don't dequeue because the store never sets `HasActivatedStore` to true, which only happens via this call to `Store.InitializeAsync()` which only happens in `OnAfterRenderAsync` which isn't called on the server anymore, so it intuitively feels like this might fix the problem.

I'll follow up if I'm able to validate it locally furhter.