### PR TITLE
Add support to RoutingMiddleware to handle relative paths in state

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/RoutingMiddleware.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/RoutingMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Routing;
+using System;
 using System.Threading.Tasks;
 
 namespace Fluxor.Blazor.Web.Middlewares.Routing;
@@ -38,13 +39,15 @@ internal class RoutingMiddleware : Middleware
 	/// <see cref="Middleware.OnInternalMiddlewareChangeEnding"/>
 	protected override void OnInternalMiddlewareChangeEnding()
 	{
-		if (Feature.State.Uri is not null && !UrlComparer.AreEqual(Feature.State.Uri, NavigationManager.Uri))
+		string fullUri = NavigationManager.ToAbsoluteUri(Feature.State.Uri).AbsoluteUri;
+		if (Feature.State.Uri is not null && !UrlComparer.AreEqual(fullUri, NavigationManager.Uri))
 			NavigationManager.NavigateTo(Feature.State.Uri);
 	}
 
 	private void LocationChanged(object sender, LocationChangedEventArgs e)
 	{
-		if (Dispatcher is not null && !IsInsideMiddlewareChange && !UrlComparer.AreEqual(e.Location, Feature.State.Uri))
+		string fullUri = NavigationManager.ToAbsoluteUri(Feature.State.Uri).AbsoluteUri;
+		if (Dispatcher is not null && !IsInsideMiddlewareChange && !UrlComparer.AreEqual(e.Location, fullUri))
 			Dispatcher.Dispatch(new GoAction(e.Location));
 	}
 }


### PR DESCRIPTION
When dispatching a GoAction with a relative path, the following exception is thrown:

```
Error: Microsoft.AspNetCore.Components.LocationChangeException: An exception occurred while dispatching a location changed event.
 ---> System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at Fluxor.Blazor.Web.Middlewares.Routing.UrlComparer.AreEqual(String first, String second) in C:\Data\Mine\Code\Fluxor\Source\Lib\Fluxor.Blazor.Web\Middlewares\Routing\UrlComparer.cs:line 8
   at Fluxor.Blazor.Web.Middlewares.Routing.RoutingMiddleware.LocationChanged(Object sender, LocationChangedEventArgs e) in C:\Data\Mine\Code\Fluxor\Source\Lib\Fluxor.Blazor.Web\Middlewares\Routing\RoutingMiddleware.cs:line 47
   at Microsoft.AspNetCore.Components.NavigationManager.NotifyLocationChanged(Boolean isInterceptedLink)
   --- End of inner exception stack trace ---
   at Microsoft.AspNetCore.Components.NavigationManager.NotifyLocationChanged(Boolean isInterceptedLink)
   at Microsoft.AspNetCore.Components.Server.Circuits.CircuitHost.<>c__DisplayClass51_0.<OnLocationChangedAsync>b__1()
   at Microsoft.AspNetCore.Components.Rendering.RendererSynchronizationContext.<InvokeAsync>g__Execute|8_0(ValueTuple`3 state)
--- End of stack trace from previous location ---
   at Microsoft.AspNetCore.Components.Server.Circuits.CircuitHost.OnLocationChangedAsync(String uri, String state, Boolean intercepted)
```

This is due to a recent change with commit 440c592d06982d8b068bdab67aa305355cea895d.

The code introduced the new assumption that the two parts are always valid URIs. When using a relative path, this causes issues.

This fix ensures that only absolute paths are compared.