### PR TITLE
Add async overload of SubscribeToAction

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -52,8 +52,13 @@ public abstract class FluxorComponent : ComponentBase, IAsyncDisposable
 		});
 	}
 
-	/// <see cref="IActionSubscriber.SubscribeToAction{TAction}(object, Action{TAction})"/>
-	public void SubscribeToAction<TAction>(Func<TAction, Task> callback)
+	/// <summary>
+	/// Subscribes to be notified whenever a specific action is dispatched
+	/// </summary>
+	/// <typeparam name="TAction">The type of action (and its descendants) to be notified of</typeparam>
+	/// <param name="subscriber">The instance that is subscribing to notifications</param>
+	/// <param name="callback">The asynchronous action to execute whenever a qualifying action is dispatched</param>
+	public void SubscribeToActionAsync<TAction>(Func<TAction, Task> callback)
 	{
 		ActionSubscriber.SubscribeToAction<TAction>(this, action =>
 		{

--- a/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Components/FluxorComponent.cs
@@ -52,6 +52,20 @@ public abstract class FluxorComponent : ComponentBase, IAsyncDisposable
 		});
 	}
 
+	/// <see cref="IActionSubscriber.SubscribeToAction{TAction}(object, Action{TAction})"/>
+	public void SubscribeToAction<TAction>(Func<TAction, Task> callback)
+	{
+		ActionSubscriber.SubscribeToAction<TAction>(this, action =>
+		{
+			InvokeAsync(async () =>
+			{
+				if (!Disposed)
+					await callback(action);
+				StateHasChanged();
+			});
+		});
+	}
+
 	/// <summary>
 	/// Disposes of the component and unsubscribes from any state
 	/// </summary>


### PR DESCRIPTION
When using `FluxorComponent.SubscribeToAction` to work with mutable objects (such as DTO's), I often need to transition into async code. An example would be where we are binding a DataGrid to a DTO. The 3rd party components methods for refreshing are asynchronous.

In this scenario, it would really useful to have an async variant for the `SubscribeToAction` method, replacing the `Action<TAction> callback` parameter with `Func<TAction, Task> callback` and then awaiting this inside of `InvokeAsync`. This avoids `StateHasChanged` being called before the handler has fully completed.

In my own project, I have a custom version of FluxorComponent where we have implemented this and it is working well. I wanted to suggest adding this to the base component.