### PR TITLE
Fix NullReferenceException in ReduxDevTools - Fixes #543

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -2,6 +2,7 @@
 
 ## New in 6.7
 * Fix StoreInitialize error ([#535](https://github.com/mrpmorris/Fluxor/issues/535))
+* Fix NullReferenceException when using ReduxDevTools ([#543](https://github.com/mrpmorris/Fluxor/issues/543))
 
 ## New in 6.6
 * Allow DependencyInjection >=8 < 10 for .net 8 ([#530](https://github.com/mrpmorris/Fluxor/issues/530))

--- a/Source/Lib/Fluxor.Blazor.Web.ReduxDevTools/Internal/ReduxDevToolsMiddleware.cs
+++ b/Source/Lib/Fluxor.Blazor.Web.ReduxDevTools/Internal/ReduxDevToolsMiddleware.cs
@@ -61,9 +61,12 @@ public sealed class ReduxDevToolsMiddleware : WebMiddleware
 				string.Join("\r\n",
 					new StackTrace(fNeedFileInfo: true)
 						.GetFrames()
-						.Select(x => $"at {x.GetMethod().DeclaringType.FullName}.{x.GetMethod().Name} ({x.GetFileName()}:{x.GetFileLineNumber()}:{x.GetFileColumnNumber()})")
+						.Select(x => new { StackFrame = x, Method = x.GetMethod() })
+						.Where(x => x.Method?.DeclaringType is not null)
+						.Select(x => $"at {x.Method.DeclaringType.FullName}.{x.Method.Name} ({x.StackFrame.GetFileName()}:{x.StackFrame.GetFileLineNumber()}:{x.StackFrame.GetFileColumnNumber()})")
 						.Where(x => Options.StackTraceFilterRegex?.IsMatch(x) != false)
-						.Take(maxItems));
+						.Take(maxItems)
+				);
 		lock (SyncRoot)
 		{
 			IDictionary<string, object> state = GetState();


### PR DESCRIPTION
ReduxDevTools could throw a NullReferenceException when a method in the call stack did not have a declaring type (lambas for example).