### PR TITLE
Add FeatureAttribute.DebuggerBrowsable property to exclude features from ReduxDevTools serialization (Fixes #541)

### DIFF
--- a/Docs/releases.md
+++ b/Docs/releases.md
@@ -1,5 +1,8 @@
 # Releases
 
+## New in 6.8
+* Added DebuggerBrowsable property to FeatureAttribute to prevent state being sent to ReduxDevTools ([#541](https://github.com/mrpmorris/Fluxor/issues/541))
+
 ## New in 6.7
 * Fix StoreInitialize error ([#535](https://github.com/mrpmorris/Fluxor/issues/535))
 * Fix NullReferenceException when using ReduxDevTools ([#543](https://github.com/mrpmorris/Fluxor/issues/543))

--- a/Source/Lib/Fluxor.Blazor.Web.ReduxDevTools/Internal/ReduxDevToolsMiddleware.cs
+++ b/Source/Lib/Fluxor.Blazor.Web.ReduxDevTools/Internal/ReduxDevToolsMiddleware.cs
@@ -83,7 +83,8 @@ public sealed class ReduxDevToolsMiddleware : WebMiddleware
 	private IDictionary<string, object> GetState()
 	{
 		var state = new Dictionary<string, object>();
-		foreach (IFeature feature in Store.Features.Values.OrderBy(x => x.GetName()))
+		var serializableFeatures = Store.Features.Values.Where(x => x.DebuggerBrowsable);
+		foreach (IFeature feature in serializableFeatures.OrderBy(x => x.GetName()))
 			state[feature.GetName()] = feature.GetState();
 		return state;
 	}

--- a/Source/Lib/Fluxor/DependencyInjection/Wrappers/FeatureStateWrapper.cs
+++ b/Source/Lib/Fluxor/DependencyInjection/Wrappers/FeatureStateWrapper.cs
@@ -7,11 +7,11 @@ internal class FeatureStateWrapper<TState> : Feature<TState>
 	private readonly string Name;
 	private readonly Func<object> CreateInitialStateFunc;
 
-	public FeatureStateWrapper(
-		FeatureStateInfo info)
+	public FeatureStateWrapper(FeatureStateInfo info)
 	{
 		Name = info.FeatureStateAttribute.Name ?? typeof(TState).FullName;
 		MaximumStateChangedNotificationsPerSecond = info.FeatureStateAttribute.MaximumStateChangedNotificationsPerSecond;
+		DebuggerBrowsable = info.FeatureStateAttribute.DebuggerBrowsable;
 		CreateInitialStateFunc = info.CreateInitialStateFunc;
 	}
 

--- a/Source/Lib/Fluxor/Feature.cs
+++ b/Source/Lib/Fluxor/Feature.cs
@@ -17,6 +17,9 @@ public abstract class Feature<TState> : IFeature<TState>
 	/// <see cref="IFeature.GetState"/>
 	public virtual object GetState() => State;
 
+	/// <see cref="IFeature.DebuggerBrowsable"/>
+	public virtual bool DebuggerBrowsable { get; set; }
+
 	/// <see cref="IFeature.RestoreState(object)"/>
 	public virtual void RestoreState(object value) => State = (TState)value;
 

--- a/Source/Lib/Fluxor/FeatureStateAttribute.cs
+++ b/Source/Lib/Fluxor/FeatureStateAttribute.cs
@@ -7,5 +7,6 @@ public class FeatureStateAttribute : Attribute
 {
 	public string Name { get; set; }
 	public string CreateInitialStateMethodName { get; set; }
+	public bool DebuggerBrowsable { get; set; } = true;
 	public byte MaximumStateChangedNotificationsPerSecond { get; set; }
 }

--- a/Source/Lib/Fluxor/IFeature.cs
+++ b/Source/Lib/Fluxor/IFeature.cs
@@ -15,9 +15,15 @@ public interface IFeature
 	string GetName();
 
 	/// <summary>
+	/// Gets a value indicating whether the property should be visible
+	/// in any attached debugger (e.g. ReduxDevTools).
+	/// </summary>
+	bool DebuggerBrowsable { get; }
+
+	/// <summary>
 	/// If greater than 0, the feature will not execute state changes
 	/// more often than this many times per second. Additional notifications
-	/// will be surpressed, and observers will be notified of the latest
+	/// will be supressed, and observers will be notified of the latest
 	/// state when the time window has elapsed to allow another notification.
 	/// </summary>
 	byte MaximumStateChangedNotificationsPerSecond { get; set; }

--- a/Source/Lib/Fluxor/IFeature.cs
+++ b/Source/Lib/Fluxor/IFeature.cs
@@ -23,7 +23,7 @@ public interface IFeature
 	/// <summary>
 	/// If greater than 0, the feature will not execute state changes
 	/// more often than this many times per second. Additional notifications
-	/// will be supressed, and observers will be notified of the latest
+	/// will be suppressed, and observers will be notified of the latest
 	/// state when the time window has elapsed to allow another notification.
 	/// </summary>
 	byte MaximumStateChangedNotificationsPerSecond { get; set; }

--- a/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/ReduxDevToolsTutorial/Client/Store/CounterUseCase/CounterState.cs
+++ b/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/ReduxDevToolsTutorial/Client/Store/CounterUseCase/CounterState.cs
@@ -2,7 +2,7 @@
 
 namespace FluxorBlazorWeb.ReduxDevToolsTutorial.Client.Store.CounterUseCase
 {
-	[FeatureState(Name = "Counter")]
+	[FeatureState(Name = "Counter", DebuggerBrowsable = false)]
 	public class CounterState
 	{
 		public int ClickCount { get; }


### PR DESCRIPTION
* Added DebuggerBrowsable property to FeatureAttribute to prevent state being sent to ReduxDevTools ([#541](https://github.com/mrpmorris/Fluxor/issues/541))