### PR TITLE
Fluxor doc fixes

### DIFF
--- a/Source/Tutorials/02-Blazor/02B-EffectsTutorial/README.md
+++ b/Source/Tutorials/02-Blazor/02B-EffectsTutorial/README.md
@@ -114,7 +114,7 @@ can declare our reducer method without that parameter, like so:
 ```c#
 public static class Reducers
 {
-  [ReducerMethod]
+  [ReducerMethod(typeof(FetchForecastsAction))]
   public static WeatherState ReduceFetchForecastsAction(WeatherState state) =>
     new WeatherState(IsLoading: true, Forecasts: []);
 }

--- a/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/README.md
+++ b/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/README.md
@@ -57,7 +57,7 @@ services.AddFluxor(o =>
  * Latency: How often actions are added to the plugin.
  * MaximumHistoryLength: How many actions at most should be displayed in the plugin.
 
-There is also an option to have Fluxor pass the strack trace to `ReduxDevTools`. This is useful
+There is also an option to have Fluxor pass the stack trace to `ReduxDevTools`. This is useful
 for when an action is being dispatched and you need to identify where it was dispatched from.
 
 ```c#

--- a/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/README.md
+++ b/Source/Tutorials/02-Blazor/02D-ReduxDevToolsTutorial/README.md
@@ -5,7 +5,7 @@
 [Redux Dev Tools][ReduxDevToolsLink] is a browser plugin for
 [Chrome][ChromePluginLink] and [Firefox][FirefoxPluginLink].
 
-![](./../../../../images/redux-dev-tools.jpg)
+![](./../../../../Images/redux-dev-tools.jpg)
 
 **NOTE:** ReduxDevTools allows the user to alter the state of your store
 directly. This might be a security flaw, so you should only reference
@@ -78,7 +78,7 @@ Options for `EnableStackTrace` are
 
 Note that determining the stack trace is a computationally expensive operation.
 
-![](./../../../../images/redux-dev-tools-trace.jpg)
+![](./../../../../Images/redux-dev-tools-trace.jpg)
 
  [ReduxDevToolsLink]: https://github.com/zalmoxisus/redux-devtools-extension
  [ChromePluginLink]: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en


### PR DESCRIPTION
This pull request contains minor documentation updates to the Blazor tutorial files. The changes include correcting image paths, fixing a typo, and clarifying reducer attribute usage.

Documentation improvements:

* Updated image paths in `02D-ReduxDevToolsTutorial/README.md` to use the correct `Images` directory to ensure images render properly. [[1]](diffhunk://#diff-819ece59085c3d9039d02433c16f5e5c11b9b3520b09c6b14a185e4b3b24ee9cL8-R8) [[2]](diffhunk://#diff-819ece59085c3d9039d02433c16f5e5c11b9b3520b09c6b14a185e4b3b24ee9cL81-R81)
* Fixed a typo ("strack trace" to "stack trace") in `02D-ReduxDevToolsTutorial/README.md`.
* Fixed the usage of the `[ReducerMethod]` attribute in `02B-EffectsTutorial/README.md` by specifying the action type parameter.