### PR TITLE
fix broken references

### DIFF
--- a/Source/Lib/Fluxor/EffectMethodAttribute.cs
+++ b/Source/Lib/Fluxor/EffectMethodAttribute.cs
@@ -5,7 +5,7 @@ namespace Fluxor;
 ///	<summary>
 ///		Identifies a method as an Effect handler to be triggered in response to an action. This is an
 ///		alternative to using <see cref="IEffect"/> or <see cref="Effect{TTriggerAction}"/> and
-///		will be discovered when using <see cref="DependencyInjection.Options.UseDependencyInjection(System.Reflection.Assembly[])"/>.
+///		will be discovered when using <see cref="DependencyInjection.FluxorOptions.ScanAssemblies(System.Reflection.Assembly, System.Reflection.Assembly[])"/>.
 ///		<para>
 ///			When no ActionType is specified <see cref="EffectMethodAttribute.EffectMethodAttribute()"/> then the method signature must be
 ///				({ActionType} action, IDispatcher dispatcher) => Task

--- a/Source/Lib/Fluxor/Feature.cs
+++ b/Source/Lib/Fluxor/Feature.cs
@@ -5,25 +5,25 @@ using System.Linq;
 
 namespace Fluxor;
 
-/// <see cref="IFeature{TState}"/>
+/// <inheritdoc/>
 public abstract class Feature<TState> : IFeature<TState>
 {
-	/// <see cref="IFeature.MaximumStateChangedNotificationsPerSecond"/>
+	/// <inheritdoc/>
 	public byte MaximumStateChangedNotificationsPerSecond { get; set; }
 
-	/// <see cref="IFeature.GetName"/>
+	/// <inheritdoc/>
 	public abstract string GetName();
 
-	/// <see cref="IFeature.GetState"/>
+	/// <inheritdoc/>
 	public virtual object GetState() => State;
 
-	/// <see cref="IFeature.DebuggerBrowsable"/>
+	/// <inheritdoc/>
 	public virtual bool DebuggerBrowsable { get; set; } = true;
 
-	/// <see cref="IFeature.RestoreState(object)"/>
+	/// <inheritdoc/>
 	public virtual void RestoreState(object value) => State = (TState)value;
 
-	/// <see cref="IFeature.GetStateType"/>
+	/// <inheritdoc/>
 	public virtual Type GetStateType() => typeof(TState);
 
 	/// <summary>
@@ -70,7 +70,7 @@ public abstract class Feature<TState> : IFeature<TState>
 	}
 
 	private TState _State;
-	/// <see cref="IFeature{TState}.State"/>
+	/// <inheritdoc/>
 	public virtual TState State
 	{
 		get
@@ -105,7 +105,7 @@ public abstract class Feature<TState> : IFeature<TState>
 		}
 	}
 
-	/// <see cref="IFeature{TState}.AddReducer(IReducer{TState})"/>
+	/// <inheritdoc/>
 	public virtual void AddReducer(IReducer<TState> reducer)
 	{
 		if (reducer is null)
@@ -113,7 +113,7 @@ public abstract class Feature<TState> : IFeature<TState>
 		Reducers.Add(reducer);
 	}
 
-	/// <see cref="IFeature.ReceiveDispatchNotificationFromStore(object)"/>
+	/// <inheritdoc/>
 	public virtual void ReceiveDispatchNotificationFromStore(object action)
 	{
 		if (action is null)

--- a/Source/Lib/Fluxor/IFeature.cs
+++ b/Source/Lib/Fluxor/IFeature.cs
@@ -78,6 +78,5 @@ public interface IFeature<TState> : IFeature
 	/// Adds an instance of a reducer to this feature
 	/// </summary>
 	/// <param name="reducer">The reducer instance</param>
-	/// <seealso cref="DependencyInjection.Options.UseDependencyInjection(System.Reflection.Assembly[])"/>
 	void AddReducer(IReducer<TState> reducer);
 }


### PR DESCRIPTION
Fixes #565 

  - Update broken <see cref> in EffectMethodAttribute.cs to reference FluxorOptions.ScanAssemblies
  - Remove orphaned <seealso> from IFeature.AddReducer
  - Replace <see cref="IFeature..."/> with <inheritdoc/> in Feature.cs so IDEs show docs directly on
  hover