### PR TITLE
Preserve stack trace by using ExceptionDispatchInfo

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/StoreInitializer.cs
@@ -67,7 +67,7 @@ public class StoreInitializer : FluxorComponent
 		{
 			Exception exception = ExceptionToThrow;
 			ExceptionToThrow = null;
-			throw exception;
+			ExceptionDispatchInfo.Capture(exception).Throw();
 		}
 	}
 


### PR DESCRIPTION
If an expection is re-thrown in `OnAfterRender(bool firstRender)` the stack trace is lost, making it quite difficult to determine the cause of the issue. With this in place the stack trace now includes those details.

Before:

```
System.NullReferenceException: Object reference not set to an instance of an object.
  at Fluxor.Blazor.Web.StoreInitializer.OnAfterRender(Boolean firstRender) in D:\\a\\Fluxor\\Fluxor\\Source\\Lib\\Fluxor.Blazor.Web\\StoreInitializer.cs:line 68
  at Microsoft.AspNetCore.Components.ComponentBase.Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync()
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.NotifyRenderCompletedAsync()
```

After:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at ...<BussinessEffect>.HandleAsync(RestoreSelectionFromLocalStorageAction action, IDispatcher dispatcher) in /home/vsts/work/.../Effects.cs:line 217
      at Fluxor.Store.<>c__DisplayClass35_0.<<TriggerEffects>b__2>d.MoveNext() in D:\\a\\Fluxor\\Fluxor\\Source\\Lib\\Fluxor\\Store.cs:line 225
      --- End of stack trace from previous location ---
         at Fluxor.Blazor.Web.StoreInitializer.OnAfterRender(Boolean firstRender) in D:\\a\\Fluxor\\Fluxor\\Source\\Lib\\Fluxor.Blazor.Web\\StoreInitializer.cs:line 68
            at Microsoft.AspNetCore.Components.ComponentBase.Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync()
               at Microsoft.AspNetCore.Components.Rendering.ComponentState.NotifyRenderCompletedAsync()
```