### PR TITLE
Add Replace to GoAction

### DIFF
--- a/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/Effects.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/Effects.cs
@@ -20,7 +20,7 @@ internal class Effects
 		{
 			// Only navigate if we are not already at the URI specified,
 			// or if we have been told to do a proper page reload (ForceLoad)
-			NavigationManager.NavigateTo(action.NewUri, action.ForceLoad);
+			NavigationManager.NavigateTo(action.NewUri, action.ForceLoad, action.Reload);
 		}
 		return Task.CompletedTask;
 	}

--- a/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/Effects.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/Effects.cs
@@ -20,7 +20,7 @@ internal class Effects
 		{
 			// Only navigate if we are not already at the URI specified,
 			// or if we have been told to do a proper page reload (ForceLoad)
-			NavigationManager.NavigateTo(action.NewUri, action.ForceLoad, action.Reload);
+			NavigationManager.NavigateTo(action.NewUri, action.ForceLoad, action.Replace);
 		}
 		return Task.CompletedTask;
 	}

--- a/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/GoAction.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/GoAction.cs
@@ -17,12 +17,37 @@ public class GoAction
 	public bool ForceLoad { get; }
 
 	/// <summary>
+	/// If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack
+	/// </summary>
+	public bool Reload { get; }
+
+	/// <summary>
 	/// Creates a new instance of the action
 	/// </summary>
-	/// <param name="newUri"></param>
-	public GoAction(string newUri, bool forceLoad = false)
+	/// <param name="newUri">The new address to navigate to</param>
+	public GoAction(string newUri) : this(newUri, false)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new instance of the action
+	/// </summary>
+	/// <param name="newUri">The new address to navigate to</param>
+	/// <param name="forceLoad">When true forces a real browser navigation and page reload</param>
+	public GoAction(string newUri, bool forceLoad = false) : this(newUri, forceLoad, false)
+	{
+	}
+
+	/// <summary>
+	/// Creates a new instance of the action
+	/// </summary>
+	/// <param name="newUri">The new address to navigate to</param>
+	/// <param name="forceLoad">When true forces a real browser navigation and page reload</param>
+	/// <param name="reload">If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack</param>
+	public GoAction(string newUri, bool forceLoad = false, bool reload = false)
 	{
 		NewUri = newUri;
 		ForceLoad = forceLoad;
+		Reload = reload;
 	}
 }

--- a/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/GoAction.cs
+++ b/Source/Lib/Fluxor.Blazor.Web/Middlewares/Routing/GoAction.cs
@@ -19,7 +19,7 @@ public class GoAction
 	/// <summary>
 	/// If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack
 	/// </summary>
-	public bool Reload { get; }
+	public bool Replace { get; }
 
 	/// <summary>
 	/// Creates a new instance of the action
@@ -43,11 +43,11 @@ public class GoAction
 	/// </summary>
 	/// <param name="newUri">The new address to navigate to</param>
 	/// <param name="forceLoad">When true forces a real browser navigation and page reload</param>
-	/// <param name="reload">If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack</param>
-	public GoAction(string newUri, bool forceLoad = false, bool reload = false)
+	/// <param name="replace">If true, replaces the current entry in the history stack. If false, appends the new entry to the history stack</param>
+	public GoAction(string newUri, bool forceLoad = false, bool replace = false)
 	{
 		NewUri = newUri;
 		ForceLoad = forceLoad;
-		Reload = reload;
+		Replace = replace;
 	}
 }


### PR DESCRIPTION
Closes #580.

 - Added Replace property to GoAction.
 - Added two new constructor overloads in GoAction:
   - With new replace parameter
   - With one parameter to resolve eroor `The call is ambiguous between the following methods or properties: 'Fluxor.Blazor.Web.Middlewares.Routing.GoAction.GoAction(string, bool)' and 'Fluxor.Blazor.Web.Middlewares.Routing.GoAction.GoAction(string, bool, bool)'`
  - Added usage of property Replace in Routing Effect.
  - Added summary to parameters in GoAction.