### PR TITLE
Release IsDequeuing when an ActionDispatched subscriber throws

### DIFF
--- a/Source/Lib/Fluxor.UnitTests/StoreTests/DispatchTests/DispatchTests.cs
+++ b/Source/Lib/Fluxor.UnitTests/StoreTests/DispatchTests/DispatchTests.cs
@@ -183,6 +183,87 @@ public class DispatchTests : IAsyncLifetime
 		dispatcher.Dispatch(primaryAction);
 	}
 
+	[Fact]
+	public void WhenActionDispatchedListenerDoesNotThrow_ThenActionsAreDispatchedInTheOrderTheyWereQueued()
+	{
+		var firstAction = new object();
+		var secondAction = new object();
+
+		var receivedActions = new List<object>();
+		var dispatcher = new Dispatcher();
+		dispatcher.ActionDispatched += (_, args) => receivedActions.Add(args.Action);
+
+		dispatcher.Dispatch(firstAction);
+		dispatcher.Dispatch(secondAction);
+
+		Assert.Equal(2, receivedActions.Count);
+		Assert.Same(firstAction, receivedActions[0]);
+		Assert.Same(secondAction, receivedActions[1]);
+	}
+
+	[Fact]
+	public void WhenActionDispatchedListenerThrows_ThenTheExceptionIsPassedOnToTheCaller()
+	{
+		var actionThatThrows = new object();
+
+		var dispatcher = new Dispatcher();
+		dispatcher.ActionDispatched += (_, _) => throw new InvalidOperationException();
+
+		Assert.Throws<InvalidOperationException>(() => dispatcher.Dispatch(actionThatThrows));
+	}
+
+	[Fact]
+	public void WhenActionDispatchedListenerThrows_ThenSubsequentActionsAreStillDispatched()
+	{
+		var actionThatThrows = new object();
+		var subsequentAction = new object();
+
+		var receivedActions = new List<object>();
+		var dispatcher = new Dispatcher();
+		dispatcher.ActionDispatched += (_, args) =>
+		{
+			receivedActions.Add(args.Action);
+			if (args.Action == actionThatThrows)
+				throw new InvalidOperationException();
+		};
+
+		Assert.Throws<InvalidOperationException>(() => dispatcher.Dispatch(actionThatThrows));
+		dispatcher.Dispatch(subsequentAction);
+
+		Assert.Equal(2, receivedActions.Count);
+		Assert.Same(actionThatThrows, receivedActions[0]);
+		Assert.Same(subsequentAction, receivedActions[1]);
+	}
+
+	[Fact]
+	public void WhenActionDispatchedListenerThrows_ThenActionsAlreadyQueuedAreDispatchedOnTheNextDispatch()
+	{
+		var actionThatThrows = new object();
+		var actionQueuedBehindIt = new object();
+		var subsequentAction = new object();
+
+		var receivedActions = new List<object>();
+		var dispatcher = new Dispatcher();
+		dispatcher.ActionDispatched += (_, args) =>
+		{
+			receivedActions.Add(args.Action);
+			if (args.Action != actionThatThrows)
+				return;
+
+			// Dispatched while the dispatcher is draining, so it is still queued when the exception is thrown
+			dispatcher.Dispatch(actionQueuedBehindIt);
+			throw new InvalidOperationException();
+		};
+
+		Assert.Throws<InvalidOperationException>(() => dispatcher.Dispatch(actionThatThrows));
+		dispatcher.Dispatch(subsequentAction);
+
+		Assert.Equal(3, receivedActions.Count);
+		Assert.Same(actionThatThrows, receivedActions[0]);
+		Assert.Same(actionQueuedBehindIt, receivedActions[1]);
+		Assert.Same(subsequentAction, receivedActions[2]);
+	}
+
 	public DispatchTests()
 	{
 		Dispatcher = new Dispatcher();

--- a/Source/Lib/Fluxor/Dispatcher.cs
+++ b/Source/Lib/Fluxor/Dispatcher.cs
@@ -54,19 +54,33 @@ public class Dispatcher : IDispatcher
 				return;
 			IsDequeuing = true;
 		}
-		do
+		try
 		{
-			object dequeuedAction = null;
-			EventHandler<ActionDispatchedEventArgs> callbacks;
+			do
+			{
+				object dequeuedAction = null;
+				EventHandler<ActionDispatchedEventArgs> callbacks;
+				lock (SyncRoot)
+				{
+					callbacks = _ActionDispatched;
+					IsDequeuing = callbacks is not null && QueuedActions.TryDequeue(out dequeuedAction);
+					if (!IsDequeuing)
+						return;
+				}
+
+				callbacks(this, new ActionDispatchedEventArgs(dequeuedAction));
+			} while (true);
+		}
+		catch
+		{
+			// The loop clears IsDequeuing inside the same lock that observes the queue is empty, so the
+			// normal exit path must be left alone. Only an abnormal exit needs to release it here, and
+			// doing so is safe because no other thread can have started dequeuing while the flag was set.
 			lock (SyncRoot)
 			{
-				callbacks = _ActionDispatched;
-				IsDequeuing = callbacks is not null && QueuedActions.TryDequeue(out dequeuedAction);
-				if (!IsDequeuing)
-					return;
+				IsDequeuing = false;
 			}
-
-			callbacks(this, new ActionDispatchedEventArgs(dequeuedAction));
-		} while (true);
+			throw;
+		}
 	}
 }


### PR DESCRIPTION
Closes #581

## Root cause

`Dispatcher.DequeueActions` sets `IsDequeuing` before draining the queue, but only clears it on the path where the queue is observed to be empty. The subscriber callback is invoked outside the lock, so if it throws, the exception unwinds past the only line that clears the flag.

From then on the dispatcher is inert: every `Dispatch` enqueues the action and then returns at the `if (IsDequeuing) return` guard. No exception, no diagnostic, no state change, and the queue keeps growing. Since a reducer runs synchronously under `Dispatcher.DequeueActions` (via `Store.ActionDispatched` -> `Store.DequeueActions` -> `Feature<TState>.ReceiveDispatchNotificationFromStore`), a single throwing reducer disables the dispatcher permanently.

`Store.DequeueActions` already protects its equivalent `IsDispatching` flag with `try`/`finally`, added for #537. `Dispatcher` never got the same treatment.

## The fix

The dequeue loop is wrapped so that the flag is also released when the loop exits abnormally:

```csharp
catch
{
	lock (SyncRoot)
	{
		IsDequeuing = false;
	}
	throw;
}
```

### Why `catch` and not `finally`

This is the part worth reviewing closely, because the obvious `finally { IsDequeuing = false; }` is not correct here.

On the normal path the loop clears the flag *inside the same lock* that observes the queue is empty, and returns while still holding that lock. That atomicity is load-bearing. If the flag were instead cleared by a `finally` after the lock had been released, this interleaving becomes possible:

1. Thread A takes the lock, sees the queue is empty, releases the lock, and heads for the `finally`.
2. Thread B dispatches: enqueues, calls `DequeueActions`, sees `IsDequeuing` is still `true`, returns.
3. Thread A's `finally` sets `IsDequeuing = false`.

B's action is now sitting in the queue with nobody draining it — the same class of bug, just narrower. A `finally` that always clears would also let A stamp `false` over a `true` that B had legitimately just set, allowing two threads to drain concurrently.

Using `catch` leaves the normal path exactly as it was and only intervenes on the abnormal one. Clearing the flag there is safe without any further coordination: `IsDequeuing` is `true` for the whole time the loop owns the drain, so no other thread can have taken ownership in the gap between the throw and the `catch`.

The dequeue and enqueue semantics, the lock usage and the ordering guarantees are otherwise untouched.

### Exception propagation

The exception is deliberately still propagated to the caller of `Dispatch` via a bare `throw;`. This keeps current behaviour and confines the change to the wedge itself. Swallowing or rerouting reducer exceptions would be a change of error-handling policy and belongs in its own discussion.

Draining is likewise not resumed from inside the `catch`. Re-entering the loop during unwinding would run subscriber callbacks while an exception is in flight and could mask the original exception. Instead, actions left in the queue are picked up by the next `Dispatch`, which matches how `Store.DequeueActions` behaves after a failure.

## Tests

Four tests added to `StoreTests/DispatchTests/DispatchTests.cs`, alongside the existing `Dispatcher`-level tests already in that file:

- `WhenActionDispatchedListenerDoesNotThrow_ThenActionsAreDispatchedInTheOrderTheyWereQueued` — guards the unchanged normal path.
- `WhenActionDispatchedListenerThrows_ThenTheExceptionIsPassedOnToTheCaller` — pins the propagation behaviour described above.
- `WhenActionDispatchedListenerThrows_ThenSubsequentActionsAreStillDispatched` — the core regression.
- `WhenActionDispatchedListenerThrows_ThenActionsAlreadyQueuedAreDispatchedOnTheNextDispatch` — covers actions queued behind the throwing one, and asserts FIFO order is preserved across the failure.

The two new tests were confirmed to fail without the production change and pass with it. The other two pass either way, which is the point of including them.

`Fluxor.UnitTests` goes from 86 to 90 tests per target framework. Full solution, DEBUG and Release, net8.0/net9.0/net10.0: 112 passed, 0 failed per framework, no new warnings under `TreatWarningsAsErrors`. `Fluxor.Blazor.Web.AnalyzersUnitTests` targets `net472` and was not run locally (macOS); it is untouched by this change.
